### PR TITLE
fix(web): keep loose-list markers on the same line as their content

### DIFF
--- a/packages/web/src/components/MarkdownRenderer.tsx
+++ b/packages/web/src/components/MarkdownRenderer.tsx
@@ -225,12 +225,14 @@ export function MarkdownRenderer({ content, specTopics, idPrefix }: MarkdownRend
               </td>
             );
           },
-          // 列表
+          // 列表：用 list-outside + pl-6，marker 落在左內距溝槽並與內容首行同行。
+          // list-inside 會讓 loose list（項目間有空行、內容被包成 block <p>）的 marker 被
+          // 擠到自己一行，因為 inline 的 marker 無法與 block <p> 共用 line box。
           ul({ children }) {
-            return <ul className="list-disc list-inside mb-4 space-y-1">{children}</ul>;
+            return <ul className="list-disc list-outside pl-6 mb-4 space-y-1">{children}</ul>;
           },
           ol({ children }) {
-            return <ol className="list-decimal list-inside mb-4 space-y-1">{children}</ol>;
+            return <ol className="list-decimal list-outside pl-6 mb-4 space-y-1">{children}</ol>;
           },
           // 分隔線
           hr() {


### PR DESCRIPTION
In a **loose** list — items separated by blank lines, so each item's content is wrapped in a block `<p>` — the bullet/number is pushed onto its own line *above* the text. A `list-inside` marker can't share a line box with a block element.

## Repro

Any loose list. Standard CommonMark — no custom schema, no checkboxes required:

```markdown
- First item

- Second item

- Third item
```

<img width="950" height="850" alt="loose-list-marker-before-after" src="https://github.com/user-attachments/assets/e18577de-5478-495a-9417-e7ab243a03f0" />

I hit this viewing a change authored with the `superpowers-bridge` schema, but it isn't schema-specific — any loose list reproduces it, including a stock `proposal.md`.

## Fix

Switch `ul`/`ol` from `list-inside` to `list-outside` with a `pl-6` marker gutter. The marker sits in the gutter, inline with the first line; wrapped lines hang-indent under the text. One component, effectively a two-class change.

Two honest notes:

- **All lists** — not just loose ones — now use a hanging indent, with the marker in a 24px gutter instead of sitting flush inline. That's standard list rendering and is inherent to `list-outside`; loose and tight can't be distinguished at the `ul` level, so it can't be scoped to loose lists only.
- A flat ordered list of **100+ items** would have 3-digit markers slightly wider than the 24px gutter. Nothing clips (no `overflow-hidden` ancestor; the page's own padding absorbs it), so it's cosmetic and effectively unreachable here.

---

**Scope note:** this supersedes #21, which was closed. That earlier revision also suppressed the list marker on task items (GitHub-style) and reworked the checkbox. That was out of scope, and it had a real downside: suppressing the marker on an *ordered* task item hides its **number**, so a mixed list like

```
1. Step to do something
2. [ ] Checkbox step
3. Do this action
```

rendered as `1. → (no 2) → 3.`, losing the sequence. This PR is deliberately reduced to just the loose-list line-break fix.
