### PR TITLE
fix(web): span spec diff row tints across the full scroll width

### DIFF
--- a/packages/web/src/components/SpecDiffViewer.tsx
+++ b/packages/web/src/components/SpecDiffViewer.tsx
@@ -30,7 +30,9 @@ export function SpecDiffViewer({ oldContent, newContent, oldLabel, newLabel }: S
         </div>
       )}
       <div className="overflow-x-auto">
-        <pre className="text-sm leading-relaxed">
+        {/* w-max min-w-full: rows share the widest row's width so tints span the full
+            scrolled area instead of stopping at the first viewport width */}
+        <pre className="text-sm leading-relaxed w-max min-w-full">
           {changes.map((change, i) => (
             <DiffBlock key={i} change={change} />
           ))}


### PR DESCRIPTION
## Problem

`SpecDiffViewer` renders each diff line as a block `<div>` inside an `overflow-x-auto` container. Block elements size to their containing block's width, not to the scroll width — so whenever a diff line is wider than the container, the red/green row tints stop at the first viewport width. Scrolling right shows added/removed text on an untinted background.

## Fix

One line — add `w-max min-w-full` to the `<pre>` that wraps the diff rows:

- `w-max` lets the `<pre>` grow to its widest row, so the block-level rows (which fill the `<pre>`) all share that full width and their background tints span the entire scrollable area;
- `min-w-full` keeps the `<pre>` at least as wide as the container when nothing overflows, so tints still reach the right edge in the non-scrolling case.

## Verification

- `npm run type-check` and `npm test` pass.
- Verified in the browser against a repo whose spec history contains long lines: the scroll container measured 990px client width vs 1754px scroll width, and with the fix each tinted row measures 1754px (previously it stopped at 990px). Scrolled right, the tinted backgrounds now cover the text for the full width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
