### PR TITLE
feat(ci): add quality gates and automate the npm package release line

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release
-description: Automate spek release — update CHANGELOGs, bump version, and push tag to trigger CI/CD publish. Use when the user wants to release a new version.
+description: Automate spek release — update CHANGELOGs, bump versions on both the product and npm package lines, and push tag to trigger CI/CD publish. Use when the user wants to release a new version.
 license: MIT
 compatibility: Requires npm, git.
 metadata:
   author: spek
-  version: "1.3"
+  version: "1.4"
 ---
 
 Automate the spek release process — update CHANGELOGs, bump version, create tag, and push to trigger CI/CD.
@@ -66,9 +66,51 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
 
    Follow the shape already in each file: `- [@handle](https://github.com/handle) (Name)` with one sub-bullet per contribution, appending a sub-bullet if the handle is already listed. Match each file's own typography — `README.zh-TW.md` uses full-width parentheses（）and `——` dashes.
 
-   The same credit belongs in the CHANGELOG entry (step 3) and the GitHub Release notes (step 11). Word it as a `Thanks to [@handle](https://github.com/handle) (Name)` clause, matching the existing entries.
+   The same credit belongs in the CHANGELOG entry (step 3) and the GitHub Release notes (step 12). Word it as a `Thanks to [@handle](https://github.com/handle) (Name)` clause, matching the existing entries.
 
-5. **Update plugin.xml change-notes**
+5. **Release the npm package line (`@spekjs/core` / `@spekjs/ui`)**
+
+   These are **separate version lines** from the product line above, with their own CHANGELOGs. They
+   are no longer published from your machine — CI publishes each one when a version bump reaches
+   `master` (`.github/workflows/npm-publish.yml`). Your job here is the part CI cannot do: deciding
+   the increment.
+
+   For each package, check whether it changed since its own last release:
+
+   ```bash
+   for pkg in core ui; do
+     last=$(git tag -l "${pkg}-v*" --sort=-v:refname | head -1)
+     echo "== @spekjs/$pkg  (last released: ${last:-none})"
+     git log --oneline "${last}..HEAD" -- "packages/$pkg/src"
+   done
+   ```
+
+   No commits for a package → **that package is not released**. Say so explicitly. Unlike the three
+   product CHANGELOGs, an unchanged package gets no version and no section at all; inventing one
+   would publish an identical tarball under a new number.
+
+   For each package that did change, **decide the increment from what the changes did**, not from
+   their commit prefixes. Read the `## Impact` section of every change archived since that tag —
+   project convention requires anything affecting registry consumers (a new public export, a
+   behavior change, additive-so-minor-not-patch) to be recorded there for exactly this moment.
+
+   > Commit prefixes get this wrong about half the time in this repository. `@spekjs/core` 1.3.0
+   > came from a single `fix(core,ui):` commit that added the `./graph-node-id` export subpath, and
+   > 1.4.0 from three `fix:` / `test:` commits that changed `TaskItem.text`'s semantics for
+   > consumers. A `fix: → patch` rule would have published 1.2.1 and 1.3.1. A published version
+   > cannot be withdrawn — an under-bump is corrected only by publishing again.
+
+   Then, for each package being released:
+   - Update `packages/<pkg>/CHANGELOG.md`. Its readers are API consumers, so write about the API
+     surface, not about spek's UI. These entries do **not** go in the three product CHANGELOGs.
+   - Bump `version` in `packages/<pkg>/package.json`.
+   - Commit as `chore(npm): publish @spekjs/<pkg>@X.Y.Z` (one commit may cover both packages — see
+     `2e65a11`).
+
+   When that commit reaches `master`, CI publishes it and creates the `core-vX.Y.Z` / `ui-vX.Y.Z`
+   tag. Do **not** run `npm publish` locally, and do **not** create those tags by hand.
+
+6. **Update plugin.xml change-notes**
 
    Update `packages/intellij/src/main/resources/META-INF/plugin.xml` — replace the `<change-notes>` block with the new version's changelog content in HTML format:
 
@@ -83,7 +125,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
 
    Only include the latest version's changes (not cumulative history).
 
-6. **Commit changelog updates**
+7. **Commit changelog updates**
 
    ```bash
    git add CHANGELOG.md packages/vscode/CHANGELOG.md packages/intellij/CHANGELOG.md packages/intellij/src/main/resources/META-INF/plugin.xml
@@ -97,7 +139,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
    git commit -m "docs(readme): credit @<handle> for <what>"
    ```
 
-7. **Rebuild demo page**
+8. **Rebuild demo page**
 
    Rebuild `docs/demo.html` and badges so they reflect the latest code and openspec content:
 
@@ -113,7 +155,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
    git commit -m "Rebuild demo for v<version>"
    ```
 
-8. **Run npm version**
+9. **Run npm version**
 
    ```bash
    npm version <type-or-version> --no-git-tag-version
@@ -132,7 +174,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
    - Create git commit with version
    - Create `v<version>` git tag
 
-9. **Push to trigger CI/CD**
+10. **Push to trigger CI/CD**
 
    Ask the user for confirmation before pushing:
    > "Ready to push v<version> to origin? This will trigger the CI/CD pipelines to publish to VS Code Marketplace and JetBrains Marketplace."
@@ -141,7 +183,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
    git push --follow-tags
    ```
 
-10. **Update `v1` major version tag**
+11. **Update `v1` major version tag**
 
    After push, update the `v1` floating tag to point to the new release commit:
 
@@ -152,7 +194,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
 
    This follows the GitHub Action versioning convention — users referencing `spekhq/spek@v1` will automatically get the latest release.
 
-11. **Create GitHub Release**
+12. **Create GitHub Release**
 
     Create a GitHub Release with Marketplace publishing:
 
@@ -162,7 +204,7 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
 
     The release will be published to the GitHub Actions Marketplace (action.yml with branding is auto-detected by GitHub).
 
-12. **Show summary**
+13. **Show summary**
 
    Display:
    - New version number
@@ -175,6 +217,9 @@ Automate the spek release process — update CHANGELOGs, bump version, create ta
 **Guardrails**
 - ALWAYS update all three CHANGELOGs (root + vscode + intellij). They share one version history but are NOT identical — each drops entries irrelevant to its channel (see CLAUDE.md). A channel with nothing to report still gets a section saying so, because `npm version` publishes it at the new version regardless.
 - A credit for an external contribution goes in FOUR places — root CHANGELOG, the channel's CHANGELOG, `README.md`, `README.zh-TW.md` — plus the GitHub Release notes. Nothing verifies they agree; a missing one is only ever caught by a human reading the file.
+- The npm package line (step 5) follows the OPPOSITE rule from the three product CHANGELOGs: a package whose `src/` did not change since its last `core-v*` / `ui-v*` tag gets **no** version and **no** CHANGELOG section. Bumping it anyway republishes an identical tarball under a new number.
+- NEVER derive an `@spekjs/*` version increment from commit prefixes. Read the archived changes' `## Impact`. Two of the last four core releases would have been under-bumped by a `fix: → patch` rule, and a published version cannot be withdrawn.
+- NEVER run `npm publish` locally and NEVER hand-create a `core-v*` / `ui-v*` tag. CI does both, from the version bump alone (`.github/workflows/npm-publish.yml`). Publishing by hand skips the gates the workflow runs first, and a hand-made tag makes the next release's "what changed since" diff lie.
 - ALWAYS confirm with user before `git push`
 - If there are uncommitted changes, warn and ask to stash or commit first
 - If the working tree is dirty after changelog update, stage only changelog files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,20 @@ jobs:
 
       - run: npm ci
 
-      # Must precede the type check and every build: @spekjs/core's package entry is dist/, so web
-      # and ui type-check against packages/core/dist/*.d.ts rather than core's sources. On a fresh
-      # checkout with no core build, the type check reports errors unrelated to the change.
-      - name: Build @spekjs/core
-        run: npm run build:core
+      # Both must precede the type check and every build. core and ui each resolve through their
+      # dist/, not their sources, so web type-checks against packages/{core,ui}/dist/*.d.ts. Neither
+      # is produced by `npm ci`: core builds on `prepare`, which npm skips for a workspace root
+      # install, and ui builds on `prepublishOnly` (a `prepare` hook would run before npm creates the
+      # workspace symlinks, so ui could not resolve core and would take the whole `npm ci` down).
+      #
+      # Omitting the ui build here failed exactly once, on this workflow's first run, with
+      # "TS2307: Cannot find module '@spekjs/ui'" — invisible locally, where a dist from an earlier
+      # build is always lying around. It is the same trap that shipped the composite action broken;
+      # see the "Action build chain" requirement in openspec/specs/github-action.
+      - name: Build @spekjs/core and @spekjs/ui
+        run: |
+          npm run build:core
+          npm run build:ui
 
       - name: Test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,115 @@
+name: CI
+
+# The quality gates. Every other workflow in this repository publishes or deploys and is gated on a
+# tag; this one is the only thing that runs before code reaches master. It invokes the root npm
+# scripts rather than reimplementing any gate inline, so a contributor can reproduce a failure
+# locally with the same command. See openspec/specs/continuous-integration.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Only the checkout needs anything.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  node:
+    name: Node gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - run: npm ci
+
+      # Must precede the type check and every build: @spekjs/core's package entry is dist/, so web
+      # and ui type-check against packages/core/dist/*.d.ts rather than core's sources. On a fresh
+      # checkout with no core build, the type check reports errors unrelated to the change.
+      - name: Build @spekjs/core
+        run: npm run build:core
+
+      - name: Test
+        run: npm test
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      # build:demo follows NODE_ENV. Without production set, this exercises a React dev build —
+      # a different artifact from the one that ships, which is how v1.8.0 put a dev build on the
+      # live demo page.
+      - name: Build demo
+        run: npm run build:demo
+        env:
+          NODE_ENV: production
+
+  kotlin:
+    name: Kotlin gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # packages/intellij re-implements core's scanning rules in Kotlin. Nothing links the two
+      # implementations, so this suite is the only thing that observes a divergence.
+      - name: Test
+        working-directory: packages/intellij
+        run: ./gradlew test
+
+  action-smoke:
+    name: Composite action smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # spek-version MUST be the commit under test. The action checks out spekhq/spek at that ref
+      # into .spek-builder and builds from *that* copy — left at its default of "master", this job
+      # would run the pull request's workflow against master's action implementation and report
+      # green on a change that breaks the action, which is the exact failure it exists to catch.
+      - name: Run the action against this repository
+        id: spek
+        uses: ./
+        with:
+          spek-version: ${{ github.sha }}
+          generate-badges: "true"
+
+      # Assert on file contents, not on the outputs having values. A step output is set whether or
+      # not the build produced anything: when @spekjs/ui's build moved off the install-time hook,
+      # the action stopped producing ui's dist and shipped broken for a full day with every output
+      # still populated.
+      - name: Assert the action produced real output
+        run: |
+          HTML='${{ steps.spek.outputs.html-path }}'
+          BADGES='${{ steps.spek.outputs.badges-path }}'
+
+          if [ -z "$HTML" ]; then echo "::error::html-path output is empty"; exit 1; fi
+          if [ ! -s "$HTML" ]; then echo "::error::no file at html-path: $HTML"; exit 1; fi
+          echo "html-path: $HTML ($(wc -c <"$HTML") bytes)"
+
+          if [ -z "$BADGES" ]; then echo "::error::badges-path output is empty"; exit 1; fi
+          if [ ! -d "$BADGES" ]; then echo "::error::no directory at badges-path: $BADGES"; exit 1; fi
+          count=$(find "$BADGES" -name '*.svg' -size +0c | wc -l)
+          if [ "$count" -eq 0 ]; then echo "::error::no non-empty badge in $BADGES"; exit 1; fi
+          echo "badges-path: $BADGES ($count badges)"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -103,8 +103,12 @@ jobs:
 
       - run: npm ci
 
-      - name: Build @spekjs/core
-        run: npm run build:core
+      # Both, for the same reason as ci.yml: web type-checks against core's and ui's dist/, and
+      # `npm ci` produces neither.
+      - name: Build @spekjs/core and @spekjs/ui
+        run: |
+          npm run build:core
+          npm run build:ui
 
       # The gates run here rather than chaining on ci.yml via workflow_run: that trigger evaluates
       # the workflow file from the default branch rather than the triggering commit, and getting its

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,152 @@
+# ┌──────────────────────────────────────────────────────────────────────────────────────────────┐
+# │ THIS FILE'S NAME IS CONFIGURATION. DO NOT RENAME IT.                                          │
+# │                                                                                               │
+# │ "npm-publish.yml" is registered as a trusted publisher for @spekjs/core and @spekjs/ui on     │
+# │ npmjs.com, and npm matches it exactly. Renaming this file leaves a workflow that still runs,  │
+# │ still resolves the version difference, and fails only at the authentication step — with       │
+# │ nothing indicating that a rename caused it. Rename only alongside re-registering the trusted  │
+# │ publisher for BOTH packages.                                                                  │
+# │                                                                                               │
+# │ For the same reason the publish steps stay inline: npm's OIDC validation checks the *calling* │
+# │ workflow's name when a reusable workflow is involved, so factoring them out breaks the match. │
+# └──────────────────────────────────────────────────────────────────────────────────────────────┘
+#
+# Publishes @spekjs/core and @spekjs/ui when their declared version differs from the registry.
+# The version bump itself is decided by the release flow, never inferred here — see
+# openspec/specs/npm-package-cicd.
+
+name: Publish npm packages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize: two pushes in quick succession must not race into a double publish.
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  # Cheap gate. Nearly every push to master changes no version, and this job is all that runs then.
+  check:
+    name: Check versions against the registry
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.check.outputs.core }}
+      core-version: ${{ steps.check.outputs.core-version }}
+      ui: ${{ steps.check.outputs.ui }}
+      ui-version: ${{ steps.check.outputs.ui-version }}
+      any: ${{ steps.check.outputs.any }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - id: check
+        run: |
+          any=false
+          for pkg in core ui; do
+            local_version=$(node -p "require('./packages/$pkg/package.json').version")
+            published=$(npm view "@spekjs/$pkg" versions --json 2>/dev/null || echo '[]')
+            # Membership of the full version list, rather than `npm view <pkg>@<version>`: that
+            # form signals "not published" through an E404 exit code, which conflates with every
+            # other reason the command can fail (network, auth, registry outage) — and a failure
+            # read as "not published" is a failure read as "publish it". `versions --json` also
+            # yields a bare string rather than an array when a package has exactly one version,
+            # which the check below normalizes.
+            if node -e '
+              const [v, raw] = process.argv.slice(1);
+              let arr = [];
+              try { arr = JSON.parse(raw); } catch {}
+              if (!Array.isArray(arr)) arr = [arr];
+              process.exit(arr.includes(v) ? 0 : 1);
+            ' "$local_version" "$published"; then
+              echo "@spekjs/$pkg@$local_version is already on the registry — skipping"
+              echo "$pkg=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "@spekjs/$pkg@$local_version is not on the registry — will publish"
+              echo "$pkg=true" >> "$GITHUB_OUTPUT"
+              any=true
+            fi
+            echo "$pkg-version=$local_version" >> "$GITHUB_OUTPUT"
+          done
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish
+    needs: check
+    if: needs.check.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC — trusted publishing. No npm token is stored in this repository.
+      contents: write   # pushing the release tag
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      # .nvmrc pins Node 22, which bundles npm 10 — older than trusted publishing requires. Without
+      # this the job fails at publish with an authentication error that does not name the cause.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - run: npm ci
+
+      - name: Build @spekjs/core
+        run: npm run build:core
+
+      # The gates run here rather than chaining on ci.yml via workflow_run: that trigger evaluates
+      # the workflow file from the default branch rather than the triggering commit, and getting its
+      # success coupling subtly wrong publishes on a red build — which cannot be undone, because a
+      # published version cannot be withdrawn.
+      - name: Test
+        run: npm test
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Publish @spekjs/core
+        if: needs.check.outputs.core == 'true'
+        run: npm publish -w @spekjs/core
+
+      - name: Publish @spekjs/ui
+        if: needs.check.outputs.ui == 'true'
+        run: npm publish -w @spekjs/ui
+
+      # Tags are created only after a successful publish, so they record what happened rather than
+      # gating it: a failed publish leaves the registry and the tag namespace both untouched.
+      - name: Tag the published versions
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          tagged=()
+          if [ "${{ needs.check.outputs.core }}" = "true" ]; then
+            tagged+=("core-v${{ needs.check.outputs.core-version }}:@spekjs/core@${{ needs.check.outputs.core-version }}")
+          fi
+          if [ "${{ needs.check.outputs.ui }}" = "true" ]; then
+            tagged+=("ui-v${{ needs.check.outputs.ui-version }}:@spekjs/ui@${{ needs.check.outputs.ui-version }}")
+          fi
+
+          for entry in "${tagged[@]}"; do
+            tag="${entry%%:*}"
+            msg="${entry#*:}"
+            if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              echo "tag $tag already exists — leaving it alone"
+              continue
+            fi
+            git tag -a "$tag" -m "$msg"
+            git push origin "$tag"
+            echo "pushed $tag"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,18 @@ spek — an OpenSpec content viewer. Four delivery surfaces plus one CI helper:
 
 The repo is **`spekhq/spek`**; the npm scope is **`@spekjs`** (an org name ≠ npm scope is normal — don't "fix" the mismatch).
 
-## action.yml: zero test coverage — read before touching the build chain
+## action.yml: smoke-tested only — read before touching the build chain
 
-The composite action is the only shipped artifact with **no test coverage** (`npm test` and CI never run it — a
-known trade-off). **Any change to packaging build timing / the build chain must verify the action manually**: add a
-temporary `workflow_dispatch` workflow with `uses: spekhq/spek@master` + `generate-badges: "true"`, assert that
-`html-path` / `badges-path` actually produce files, then remove it.
+CI runs a smoke job (`action-smoke` in `ci.yml`) that invokes the composite action against this repo with
+`generate-badges: "true"` and asserts the `html-path` / `badges-path` outputs point at real, non-empty files. It
+pins `spek-version: ${{ github.sha }}` — the action checks out `spekhq/spek` at that ref and builds from *that*
+copy, so the default `master` would test master's implementation and go green on a PR that breaks the action.
+
+**What it covers**: the action's own build chain produces output. That is the failure that shipped before.
+**What it does not**: any input combination other than the one it runs (`repo-path`, `output-path`, `title`,
+`spek-version` pinned to a tag), the generated HTML's *content*, and behavior on a consumer's repo layout. A
+change to those still needs manual verification — a temporary `workflow_dispatch` workflow with
+`uses: spekhq/spek@master`, asserting the outputs, then removed.
 
 - Precedent: moving `@spekjs/ui`'s build from `prepare` (install-time) to `prepublishOnly` (publish-time) made the
   action's ui build **silently vanish** — it relied on `npm ci` triggering `prepare` to get ui dist. The Marketplace
@@ -66,9 +72,18 @@ npm run build:core       # @spekjs/core
 npm run build:webview    # webview assets (for VS Code)
 npm run build:demo       # standalone demo (docs/demo.html; needs NODE_ENV=production)
 npm run build:intellij   # IntelliJ webview assets
-npm run type-check       # TypeScript type check
+npm run type-check       # type-check core + ui + web + vscode + scripts/ (tests included)
+npm run lint             # ESLint over every package's src, web's server, and scripts/
 npm test                 # core + ui + web tests
 ```
+
+**CI runs exactly these scripts** (`.github/workflows/ci.yml`, on `pull_request` + `push:[master]`), plus
+`./gradlew test` in `packages/intellij` and the action smoke job. A gate that fails in CI reproduces locally
+with the same command — that is deliberate, so don't reimplement a gate inline in the workflow.
+
+`type-check` covers **test files too**. Each of core/ui carries a `tsconfig.test.json` for that, rather than the
+build config dropping its test `exclude`: the build config emits into `dist`, and `files: ["dist"]` publishes it,
+so removing the exclude there would ship compiled tests to registry consumers.
 
 **A core change needs `npm run build:core` before web tests mean anything.** `@spekjs/core`'s package
 entry is `dist/`, so the web package imports the *built* copy, not `src/`. Editing core and running
@@ -267,6 +282,15 @@ GET /api/openspec/search?dir=...&q=...              # full-text search
   - **`@spekjs/core`** and **`@spekjs/ui`** each have their own version line and CHANGELOG
     (`packages/core/CHANGELOG.md` / `packages/ui/CHANGELOG.md`), **not written into the three above** (their readers
     are API consumers). Each must be listed in that package's `package.json` `files` (npm doesn't auto-pack a CHANGELOG)
+  - **`@spekjs/*` publishing is automated; the version decision is not.** CI publishes a package when its declared
+    version differs from the registry (`.github/workflows/npm-publish.yml`, on `push:[master]`), authenticating via
+    npm Trusted Publishing (OIDC — no token in repo secrets) and creating a `core-vX.Y.Z` / `ui-vX.Y.Z` tag on
+    success. Never run `npm publish` locally and never hand-create those tags. **The workflow's filename is
+    registered with npm and matched exactly — renaming `npm-publish.yml` leaves a workflow that still runs, still
+    resolves the version difference, and fails only at authentication, with nothing naming the cause.** The bump
+    itself is chosen by the `release` skill from the archived changes' Impact, never from commit prefixes: core
+    1.3.0 (`fix:` that added an export subpath) and 1.4.0 (`fix:`/`test:` that changed `TaskItem.text` semantics)
+    would both have been under-bumped to a patch by a prefix rule
   - **Written at release time, not inside a change.** CHANGELOG entries and version bumps (`package.json` `version`,
     `gradle.properties` `pluginVersion`) belong to the release flow — `/release` for the product line, a separate
     `chore(npm): publish …` commit for the package lines. Do **not** list them in a change's `tasks.md` or do them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ npm run build:webview  # Build webview assets for the VS Code extension
 npm run build:vscode   # Build the VS Code extension
 npm run build:intellij # Build IntelliJ webview assets
 npm run build:demo     # Build the standalone demo (docs/demo.html)
-npm run type-check     # TypeScript type check
+npm run type-check     # Type-check every package + scripts/ (test files included)
+npm run lint           # ESLint
 npm test               # Run the test suites (core + ui + web)
 ```
 
@@ -105,9 +106,14 @@ reference — several were authored by external contributors.
 2. Make your change. Keep the PR focused — one logical change per PR is easier to review.
 3. **Run the checks locally:**
    ```bash
+   npm run build:core   # first — the type check resolves core through its built dist/
    npm test
    npm run type-check
+   npm run lint
    ```
+   CI runs these same scripts on every pull request, plus `./gradlew test` in `packages/intellij`
+   (JDK 17) if you touched the IntelliJ plugin. Running them locally first just saves you a round
+   trip — nothing here is a gate you can only satisfy on CI.
 4. **Fill out the pull request template** — it prompts for the affected surface, a summary, and a
    short checklist.
 5. Open the PR against `spekhq/spek:master` and link any related issue (`Fixes #123`).

--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ npm run build:ui         # Build @spekjs/ui only
 npm run build:webview    # Build webview assets for VS Code extension
 npm run build:vscode     # Build VS Code extension
 npm run build:intellij   # Build IntelliJ webview assets
-npm run type-check       # TypeScript type check
+npm run type-check       # Type-check every package + scripts/ (tests included)
+npm run lint             # ESLint
 ```
 
 **IntelliJ Plugin build:**

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -329,7 +329,8 @@ npm run build:ui         # 僅 Build @spekjs/ui
 npm run build:webview    # Build webview 靜態資源（給 VS Code Extension 用）
 npm run build:vscode     # Build VS Code Extension
 npm run build:intellij   # Build IntelliJ webview 靜態資源
-npm run type-check       # TypeScript 型別檢查
+npm run type-check       # 型別檢查所有 package 與 scripts/（含測試檔）
+npm run lint             # ESLint
 ```
 
 **IntelliJ Plugin build：**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,44 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "**/dist/**",
+      "**/dist-demo/**",
+      "**/node_modules/**",
+      "packages/vscode/webview/**",
+      "packages/intellij/**",
+      "docs/**",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      // A leading underscore is this codebase's existing marker for "deliberately unused" — it is
+      // on interface-mandated parameters the implementation does not need (handler.ts) and on
+      // destructured fields kept for shape. Teaching the rule the convention, not weakening it.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
+      // A `let` declared bare and assigned later, whose value a closure defined in between reads,
+      // cannot become a `const` without restructuring. schema-order.ts's spawn timeout is exactly
+      // that shape, and it guards a process-kill path (DEP0190 / CVE-2024-27980) not worth
+      // rewriting for a style rule.
+      "prefer-const": ["error", { ignoreReadBeforeAssign: true }],
+    },
+  },
+  {
+    files: ["packages/ui/src/**/*.{ts,tsx}", "packages/web/src/**/*.{ts,tsx}"],
+    plugins: { "react-hooks": reactHooks },
+    rules: reactHooks.configs.recommended.rules,
+  },
+);

--- a/openspec/changes/add-ci-and-npm-publish-automation/.openspec.yaml
+++ b/openspec/changes/add-ci-and-npm-publish-automation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/add-ci-and-npm-publish-automation/design.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/design.md
@@ -138,11 +138,17 @@ regression this guards against was in the action's own build chain, not in the s
 Assertions are on file contents, not on output values — a step output is set whether or not the
 build produced anything, which is how the ui-`dist` breakage stayed invisible.
 
-*Fork caveat*: for a pull request from a fork, `github.sha` is the merge commit, which exists in the
-base repository as `refs/pull/N/merge` and is fetchable, so the pinned checkout is expected to
-resolve. If it turns out not to, the fallback is to run the smoke job on `push: master` only —
-catching a break after merge instead of before, which is still strictly better than the current
-state. Decide this by observation on the first fork pull request, not by guessing now.
+*Observed*: the pinned checkout resolves on a same-repository pull request — PR #36's smoke job
+passed, checking out `github.sha` (the `refs/pull/N/merge` commit) from `spekhq/spek` without
+special handling.
+
+*Fork caveat, still unobserved*: a fork's pull request produces a merge commit in the **base**
+repository by the same mechanism, so it is expected to resolve identically — but no fork PR has run
+against this workflow yet, and the action hard-codes `repository: spekhq/spek`, so a fork's own
+commits are genuinely absent from what it checks out. If a fork PR fails here, the fallback is to
+run the smoke job on `push: master` only: that catches a break after merge instead of before, which
+is still strictly better than not running the action at all. Decide it on the first fork
+contribution rather than pre-emptively.
 
 ### ESLint only; no Prettier
 

--- a/openspec/changes/add-ci-and-npm-publish-automation/design.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/design.md
@@ -1,0 +1,246 @@
+## Context
+
+The repository ships five surfaces (Web, VS Code, IntelliJ, the demo page, the composite action) and
+publishes two npm packages, with no automated gate on any of it. The three existing workflows all
+publish or deploy; none runs on `pull_request`.
+
+Constraints that shape the design:
+
+- **`@spekjs/core`'s package entry is `dist/`.** `web` and `ui` type-check against
+  `packages/core/dist/*.d.ts`, not core's sources, so any gate must build core first or it reports
+  errors unrelated to the change under test.
+- **`core` and `ui` build and type-check with the same `tsconfig.json`**, which emits to `dist` and
+  is what `files: ["dist"]` publishes. The test `exclude` is therefore load-bearing for the build
+  even though it is a hole in the check.
+- **`@spekjs/ui` builds at publish time, not install time.** A `prepare` hook runs before npm creates
+  the workspace symlinks, so ui's build cannot resolve `@spekjs/core` and takes `npm ci` down with
+  it. Anything needing ui's `dist` must build it explicitly.
+- **The composite action checks out `spekhq/spek` at `spek-version` (default `master`) into
+  `.spek-builder`** and builds from that copy — not from the caller's checkout.
+- **npm Trusted Publishing requires npm ≥ 11.5.1 and Node ≥ 22.14.0.** `.nvmrc` pins Node 22.22.0,
+  which satisfies the Node floor but ships npm 10.9.4 — below the npm floor.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A pull request cannot merge without tests, type checks, lint, and builds having run.
+- The type check means the whole repository, including test files and `scripts/`.
+- The composite action has a gate that observes whether it actually produces output.
+- Publishing `@spekjs/core` / `@spekjs/ui` requires no local `npm publish` and no stored token.
+- Both package version lines become navigable from git history.
+
+**Non-Goals:**
+
+- Tests for `packages/vscode` (it gains `type-check` only).
+- A CI detector for unreleased package changes — see "Deliberately deferred" in the proposal.
+- Reformatting the repository. Introducing Prettier would rewrite nearly every file; see Decisions.
+- Changing how the product line (`v*` tags → VS Code / IntelliJ Marketplaces) is released.
+- Branch protection rules. Those are repository settings, not files, and are the maintainer's to
+  apply once the workflow reports a stable status name.
+
+## Decisions
+
+### Two workflows, not one
+
+`ci.yml` (gates) and `npm-publish.yml` (publishing) stay separate files.
+
+The publishing workflow's filename is registered with the npm registry and matched exactly, so it is
+effectively immutable configuration. Folding the gates into it would make an ordinary CI refactor
+able to break publishing. Keeping them apart means `ci.yml` can be reorganized freely.
+
+*Alternative considered*: one workflow with a conditional publish job. Rejected for the coupling
+above.
+
+### The publish job re-runs the gates itself rather than chaining on CI
+
+`npm-publish.yml` runs install → build core → test → type-check itself before publishing, instead of
+triggering on `workflow_run` after `ci.yml` succeeds.
+
+`workflow_run` evaluates the workflow file from the default branch rather than the triggering
+commit, and its success/failure coupling is easy to get subtly wrong — a misconfiguration publishes
+on a red build, which is unrecoverable because a published version cannot be withdrawn. A
+self-contained job is auditable in one file.
+
+The cost is duplicated work, but only on a push that actually publishes: eight times in four months.
+
+*Alternative considered*: `workflow_run` chaining. Rejected — the failure mode is unrecoverable and
+the saving is negligible at this frequency.
+
+### Version-diff detection, skipping quietly
+
+For each package, compare the declared version against the registry (`npm view <pkg>@<version>`), and
+publish only on a difference. A version already on the registry is a **skip with a successful exit**,
+not a failure.
+
+Nearly every push to `master` changes no version. A workflow that errors on "already published"
+would make red the normal state of `master`, and a real failure would be indistinguishable from the
+noise.
+
+*Alternative considered*: a dedicated `core-v*` tag push as the trigger. Rejected — the version bump
+is already the deliberate, reviewed act; a second signal adds a step that can be forgotten without
+adding information. (The tags still exist — they are created *by* a successful publish, so they
+record what happened rather than gating it.)
+
+### npm CLI is upgraded in the job
+
+The job runs `npm install -g npm@latest` (or a pinned `npm@^11.5.1`) after `setup-node` and before
+publishing.
+
+`.nvmrc`'s Node 22.22.0 bundles npm 10.9.4, which predates trusted publishing. Without this the job
+fails at the publish step with an authentication error that does not name the cause.
+
+### One flat workflow, no reusable-workflow indirection
+
+The publish steps live directly in `npm-publish.yml`.
+
+npm's OIDC validation checks the *calling* workflow's name when a reusable workflow is involved, so
+the registered filename would no longer match what runs. `id-token: write` would also have to be
+granted at both levels.
+
+### Permissions and concurrency
+
+The publish job requests `id-token: write` (OIDC) and `contents: write` (pushing the release tag),
+and takes a `concurrency` group so two rapid pushes to `master` cannot race into a double publish.
+`ci.yml` needs neither write permission.
+
+### Test files are checked by a separate project, not by deleting the exclude
+
+Each of `core` and `ui` gains a `tsconfig.test.json` that extends its build config, clears the test
+`exclude`, and sets `noEmit`. The `type-check` script runs both the build config and the test
+config; `build` keeps using the unchanged build config.
+
+Deleting the exclude from `tsconfig.json` would compile `aggregate.test.ts` into `dist/`, and
+`files: ["dist"]` would publish it — trading a silent gap for a silent regression in what consumers
+download. `web` already includes its tests under a `noEmit` config and needs nothing; `vscode` builds
+through esbuild and its `tsconfig.json` is already `noEmit`, so it only needs the script.
+
+`scripts/` gets a small `tsconfig.scripts.json` at the root, since no existing project names it.
+
+The stale root `tsconfig.json` — project references listing only `core` and `web`, invoked by
+nothing — is **removed**. No script runs `tsc -b`, no tool resolves it (the language server and
+typescript-eslint both find the nearest per-package config), and the `type-check` script is now the
+single description of what gets checked. A second, partial description of the project graph is a
+drift source of exactly the kind this change exists to remove.
+
+### The smoke job must pin the action to the commit under test
+
+The smoke job invokes the action with `spek-version: ${{ github.sha }}`.
+
+The action checks out `spekhq/spek` at `spek-version` and builds from *that* copy. Left at the
+default `master`, the job would run the pull request's workflow file against master's action
+implementation and report green on a pull request that breaks the action — precisely the failure it
+exists to catch.
+
+It must run the real action rather than calling `build-demo.ts` / `generate-badges.ts` directly: the
+regression this guards against was in the action's own build chain, not in the scripts.
+
+Assertions are on file contents, not on output values — a step output is set whether or not the
+build produced anything, which is how the ui-`dist` breakage stayed invisible.
+
+*Fork caveat*: for a pull request from a fork, `github.sha` is the merge commit, which exists in the
+base repository as `refs/pull/N/merge` and is fetchable, so the pinned checkout is expected to
+resolve. If it turns out not to, the fallback is to run the smoke job on `push: master` only —
+catching a break after merge instead of before, which is still strictly better than the current
+state. Decide this by observation on the first fork pull request, not by guessing now.
+
+### ESLint only; no Prettier
+
+Add a flat ESLint config at the root (`typescript-eslint` recommended plus `eslint-plugin-react-hooks`
+for the web and ui sources) and a root `lint` script. Do not add Prettier; remove
+`packages/web`'s dead `format` script.
+
+The codebase is already formatted consistently. Introducing Prettier would rewrite nearly every file
+in one commit, destroying `git blame` for no defect caught. `react-hooks` earns its place — this
+codebase's correctness lives in hooks (`useFileWatcher`, `refreshTracker`, the aggregation-scope
+context), where a missing dependency is a real bug rather than a style opinion.
+
+The rule set starts at the recommended baseline. A stricter set would land with a violation backlog
+that has to be either fixed in the same change or suppressed, and a config suppressed into silence
+is the same dead gate this change is removing.
+
+### Tag namespace and backfill
+
+Release tags are `core-vX.Y.Z` and `ui-vX.Y.Z`, deliberately outside the product `v*` namespace so
+the existing publish workflows' `v[0-9]+.[0-9]+.[0-9]+` patterns cannot match them.
+
+All twelve published versions map to a commit that declared them:
+
+| tag | commit | tag | commit |
+|---|---|---|---|
+| `core-v1.0.0` | `66ffd31` | `core-v1.3.0` | `e66e631` |
+| `core-v1.1.0` | `0257e9b` | `core-v1.4.0` | `0f5c162` |
+| `core-v1.1.1` | `2e65a11` | `ui-v1.0.0` | `0939532` |
+| `core-v1.1.2` | `bc4df70` | `ui-v1.0.1` | `2e65a11` |
+| `core-v1.1.3` | `baa08b4` | `ui-v1.1.0` | `b54639e` |
+| `core-v1.2.0` | `8395812` | `ui-v1.2.0` | `494f8ce` |
+
+`2e65a11` carries two tags — it published both packages. Three versions (`core-v1.0.0`,
+`core-v1.1.0`, `ui-v1.0.0`) predate the `chore(npm): publish …` message convention, which is why the
+convention cannot be the anchor and the tags must be.
+
+Only additions: no existing tag is moved or deleted.
+
+### The version decision stays in the release skill
+
+`.agents/skills/release/SKILL.md` gains a step covering the package line: for each package, diff
+`packages/<pkg>/src` against that package's last release tag; if it changed, decide the increment
+from the archived changes' stated impact, update that package's CHANGELOG, bump the version, and
+commit `chore(npm): publish @spekjs/<pkg>@X.Y.Z`. CI takes it from there.
+
+Deriving the increment from commit prefixes was measured against this repository's history and gets
+it wrong half the time (proposal, and the `npm-package-cicd` spec). The information needed to decide
+correctly — "this adds a public export", "this changes observable behavior" — is already required to
+be recorded in a change's proposal or design by project convention. The release flow is where that
+record is read.
+
+## Risks / Trade-offs
+
+**Publishing cannot work until the trusted publisher is registered** → The workflow authenticates
+only after the maintainer configures a trusted publisher for both packages on npmjs.com, pointing at
+`spekhq/spek` and `npm-publish.yml`. Until then a version bump reaching `master` fails the publish
+job. Do the registration before the first version bump lands, and verify with a deliberate patch
+release.
+
+**A workflow rename silently breaks publishing** → The registered filename is matched exactly; a
+rename leaves a workflow that runs, resolves the version difference, and fails only at
+authentication. Mitigated by a comment at the top of the file and a note in `CLAUDE.md`, which is the
+same mechanism already used for the action's build-chain trap.
+
+**Turning on lint surfaces an unknown backlog** → The violation count is not knowable until ESLint
+is installed. Run it as the first step of that task, before writing the config, and size the rule
+set to what can be fixed in this change. Disabling a rule is acceptable when recorded with a reason;
+shipping a config that fires on nothing is not.
+
+**Type-checking tests surfaces more than the two known errors** → Only `core` was measured
+(`aggregate.test.ts`, two `TS2741`s); `ui` was measured clean, `web` already checks its tests, and
+`scripts/` has never been checked at all. Others may appear. They are in scope — that is the point
+of the change — but the count could exceed the estimate.
+
+**The smoke job is slow and network-dependent** → It performs a full `npm ci` plus core/ui builds
+inside `.spek-builder`, and fetches the OpenSpec CLI. Keep it a separate job so it does not delay the
+fast gates, and let its optional CLI install keep failing soft as it already does.
+
+**Publishing on `push: master` fires while a branch is mid-merge-train** → The concurrency group
+serializes runs; the version-diff check makes a second run a quiet skip rather than a double publish.
+
+## Migration Plan
+
+1. Land the gates (`ci.yml`, type-check expansion, test-inclusive projects, the `aggregate.test.ts`
+   fix, lint) first. This is self-contained and reversible — deleting the workflow restores the
+   status quo.
+2. Backfill the twelve tags and push them. Additive; nothing depends on them yet.
+3. Register the trusted publisher for both packages on npmjs.com.
+4. Land `npm-publish.yml` and the release-skill step.
+5. Verify with a deliberate patch release of one package, checking that the publish succeeds, the
+   provenance attestation appears on the registry, and the release tag lands on the right commit.
+
+Rollback: each step is a file deletion or a tag that nothing reads. A failed publish leaves the
+registry untouched, since the tag is created only after a successful publish.
+
+## Open Questions
+
+- Whether the smoke job's `spek-version: ${{ github.sha }}` resolves for a fork pull request. Decide
+  on observation at the first fork contribution; the fallback is stated above.
+- How large the initial ESLint backlog is, and therefore how much of the recommended rule set can
+  land enabled in this change.

--- a/openspec/changes/add-ci-and-npm-publish-automation/proposal.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/proposal.md
@@ -1,0 +1,103 @@
+## Why
+
+Nothing in this repository runs tests, type checks, or lint automatically. All three workflows in
+`.github/workflows/` are publish/deploy pipelines triggered by tags or `push`; none run on
+`pull_request`. Every quality gate is a command a human remembers to type locally (issue #16).
+
+This is not hypothetical. Two independent holes — a root `type-check` that covers only
+`@spekjs/web`, and package `tsconfig.json`s that exclude their own test files from checking while
+the suites run through `tsx` (which strips types without checking them) — currently hide a real
+defect: `packages/core/src/aggregate.test.ts` fails to type-check with two `TS2741`s (`vcs` missing
+from `WorktreeInfo`, left behind by the jj aggregation work) while `npm test` reports 60/60 passing.
+The same pair of holes produced the `defaultSchema` breakage found by hand during review of #13.
+`@spekjs/core` is published to the public registry, so this is exactly the class of defect that
+reaches downstream consumers.
+
+Separately, the npm package line is released entirely by hand: bump `package.json`, run
+`npm publish`, then write a `chore(npm): publish @spekjs/core@1.4.0` commit. Neither version line
+has a single git tag, so "what changed between core 1.3.0 and 1.4.0" cannot be answered from the
+repository. More importantly, nothing signals that a release is due — the packages stay current only
+because someone happens to notice.
+
+## What Changes
+
+- **Add `.github/workflows/ci.yml`**, running on `pull_request` and `push` to `master`: install,
+  build `@spekjs/core`, then test, type-check, lint, and build (including `build:demo`). A separate
+  job runs the Kotlin suite (`./gradlew test`, JDK 17) in `packages/intellij`.
+- **Smoke-test the composite action in CI.** `action.yml` is the only shipped artifact with no test
+  coverage, and `spek-version` defaults to `master`, so a break on master reaches every consumer
+  pinned to `@v1` immediately. A CI job invokes the action against this repository and asserts that
+  `html-path` and `badges-path` produce actual files.
+- **Make `type-check` mean the whole monorepo.** `core`, `ui`, and `vscode` gain a `type-check`
+  script; the root script runs all workspaces instead of only `web`.
+- **Type-check test files.** The `exclude` patterns that keep `__tests__` / `*.test.ts` out of
+  checking are neutralized by a test-inclusive project that CI checks — they cannot simply be
+  deleted, because `core` and `ui` build with the same config and would then emit compiled tests
+  into the `dist` they publish. Every package's `tsconfig.json` is audited for the same pattern.
+- **Type-check `scripts/`.** `scripts/build-demo.ts` and `scripts/generate-badges.ts` are named by
+  no `tsconfig.json` in the repository, so nothing checks them — and they are what the composite
+  action and the deployed demo page execute.
+- **Fix the two `TS2741`s** in `packages/core/src/aggregate.test.ts` that this exposes.
+- **Add working lint.** `packages/web` declares `lint` and `format` scripts, but neither `eslint` nor
+  `prettier` is installed and no config exists anywhere in the repository — the scripts cannot run.
+  They end up either functional and wired into CI, or removed.
+- **Add `.github/workflows/npm-publish.yml`.** On `push` to `master`, each of `@spekjs/core` and
+  `@spekjs/ui` is compared against the version on the registry; a difference publishes it, an
+  identical version is skipped quietly. Authentication uses npm Trusted Publishing (OIDC) — no
+  long-lived token in repository secrets — which also attaches provenance automatically. A
+  successful publish creates and pushes a `core-vX.Y.Z` / `ui-vX.Y.Z` tag.
+- **Extend the `release` skill to cover the npm package line.** It handles only the product line
+  today (root version → VS Code + IntelliJ). It gains a step that, for each package, checks whether
+  `src/` changed since that package's last publish tag, decides the version bump, updates that
+  package's CHANGELOG, and writes the `chore(npm): publish …` commit that CI then acts on.
+- **Backfill `core-v*` / `ui-v*` tags** onto the eight existing publish commits, so the tags describe
+  the whole history rather than starting from the next release. Tags are only added; none are
+  deleted or moved.
+
+Not included: `packages/vscode` still has no test suite. It gains `type-check` here; tests are a
+separate change.
+
+## Capabilities
+
+### New Capabilities
+
+- `continuous-integration`: the automated quality gates that run on every pull request and every
+  push to `master` — test, type-check, lint, build, the Kotlin suite, and the composite-action smoke
+  test — plus the requirement that the same gates are runnable locally by the same commands.
+- `npm-package-cicd`: how `@spekjs/core` and `@spekjs/ui` reach the npm registry — the version-diff
+  trigger, OIDC authentication, provenance, the release tag created on success, and where the
+  version-bump decision is made.
+
+### Modified Capabilities
+
+None. `core-module` and `ui-package` already require *that* each package is published and what its
+tarball contains; those requirements are unchanged. What is new is *how* a publish is triggered and
+authenticated, which is a separate capability, parallel to the existing `vscode-cicd` and
+`intellij-cicd`.
+
+## Impact
+
+**New files**: `.github/workflows/ci.yml`, `.github/workflows/npm-publish.yml`, an ESLint flat
+config at the repository root.
+
+**Modified**: root `package.json` (`type-check`, `lint`, dev dependencies);
+`packages/{core,ui,vscode}/package.json` (`type-check` script); `packages/{core,ui}/tsconfig.json`
+(remove the test excludes); `packages/web/package.json` (make `lint`/`format` real or remove them);
+`packages/core/src/aggregate.test.ts` (the two type errors);
+`.agents/skills/release/SKILL.md` (the npm package line step); `CLAUDE.md` and `CONTRIBUTING.md`
+(the gates now exist and are enforced).
+
+**Repository configuration, outside the repository**: the user must register a trusted publisher for
+both `@spekjs/core` and `@spekjs/ui` on npmjs.com, pointing at `spekhq/spek` and the workflow
+filename. Until that is done the publish job cannot authenticate. The workflow filename is part of
+that registration and matched exactly, so renaming `npm-publish.yml` later silently breaks
+publishing.
+
+**Release-notes-relevant**: no public API of either package changes. The `release` skill's behavior
+changes for whoever cuts the next release — it now also handles `@spekjs/core` and `@spekjs/ui`
+rather than leaving them to a manual afterthought.
+
+**Deliberately deferred**: no CI drift detector that watches for unreleased package changes. The
+`release` skill is the checkpoint, and all eight npm publishes to date landed on the same day as a
+product `v*` tag, so the two release lines already move together. Once the tags above exist, adding
+a detector is a `git diff core-v1.4.0..HEAD -- packages/core/src` away if drift ever appears.

--- a/openspec/changes/add-ci-and-npm-publish-automation/specs/continuous-integration/spec.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/specs/continuous-integration/spec.md
@@ -1,0 +1,201 @@
+## ADDED Requirements
+
+### Requirement: Quality gates run on every pull request and every push to master
+
+The repository SHALL provide a GitHub Actions workflow that runs the quality gates — tests, type
+checking, lint, and builds — on every `pull_request` and on every `push` to `master`.
+
+The workflow SHALL NOT be limited to tag pushes. Every other workflow in this repository is a
+publish pipeline gated on a tag; a gate that only runs at release time cannot prevent a defect from
+reaching `master`, which is what `spek-version: master` (the composite action's default) exposes to
+consumers.
+
+#### Scenario: Pull request opened
+
+- **WHEN** a pull request is opened or updated against `master`
+- **THEN** the workflow runs and reports a status on the pull request
+
+#### Scenario: Push to master
+
+- **WHEN** a commit is pushed to `master`
+- **THEN** the workflow runs against that commit
+
+#### Scenario: Failing gate blocks the report
+
+- **WHEN** any gate — test, type check, lint, or build — fails
+- **THEN** the workflow is marked failed
+
+### Requirement: Core is built before any gate that resolves it
+
+The workflow SHALL build `@spekjs/core` after installing dependencies and before running the type
+check or any build that imports it.
+
+`@spekjs/core`'s package entry is `dist/`, so `@spekjs/web` and `@spekjs/ui` type-check against
+`packages/core/dist/*.d.ts` rather than core's sources. On a fresh checkout with no core build, the
+type check reports errors that have nothing to do with the change under test.
+
+#### Scenario: Fresh runner checkout
+
+- **WHEN** the workflow runs on a runner with no pre-existing `packages/core/dist`
+- **THEN** `@spekjs/core` is built before the type check runs
+- **AND** the type check reports only errors attributable to the checked-out code
+
+### Requirement: The type check covers every TypeScript source in the repository
+
+The root `type-check` script SHALL check every workspace that contains TypeScript — `@spekjs/core`,
+`@spekjs/ui`, `@spekjs/web`, and `spek-vscode` — and each of those workspaces SHALL expose its own
+`type-check` script. It SHALL also cover the repository-root `scripts/` directory.
+
+A root script that checks a single workspace reports success for the monorepo while three of four
+packages are unchecked. `@spekjs/core` and `@spekjs/ui` are published to the public registry, so an
+unchecked package is one whose type errors reach consumers.
+
+`scripts/build-demo.ts` and `scripts/generate-badges.ts` are named by no `tsconfig.json` in the
+repository, so nothing checks them at all — and they are what the composite action and the published
+demo page actually execute.
+
+#### Scenario: Root type check covers all workspaces
+
+- **WHEN** `npm run type-check` is run at the repository root
+- **THEN** `@spekjs/core`, `@spekjs/ui`, `@spekjs/web`, and `spek-vscode` are each type-checked
+
+#### Scenario: Root scripts are type-checked
+
+- **WHEN** `npm run type-check` is run at the repository root
+- **THEN** the TypeScript files under `scripts/` are type-checked
+
+#### Scenario: A type error in any workspace fails the check
+
+- **WHEN** a type error is introduced in any one of those workspaces, or under `scripts/`
+- **THEN** `npm run type-check` exits non-zero
+
+### Requirement: Type-checking test files does not change what is published
+
+Including test files in type checking SHALL NOT cause them to be emitted into any package's build
+output.
+
+`@spekjs/core` and `@spekjs/ui` build with the same `tsconfig.json` that carries the test `exclude`,
+and both emit to `dist` while declaring `files: ["dist"]`. Removing the exclude outright would put
+compiled test files into the published tarball — trading a silent gap for a silent regression in
+what consumers download.
+
+#### Scenario: Published tarball carries no tests
+
+- **WHEN** either package's tarball is inspected after this change
+- **THEN** it contains no compiled test file
+
+#### Scenario: Build output carries no tests
+
+- **WHEN** `npm run build` completes for either package
+- **THEN** `dist/` contains no compiled test file
+
+### Requirement: Test files are type-checked
+
+Every package's TypeScript configuration SHALL include that package's test files in type checking.
+No package SHALL exclude its own tests from the type check.
+
+The test suites run through `tsx`, which strips types without checking them, so a type-invalid test
+file runs green. Combined with an exclude, a broken test fixture is invisible to both gates at once:
+`packages/core/src/aggregate.test.ts` currently fails to type-check with two `TS2741`s while
+`npm test` reports every test passing, and the same pair of holes hid the `defaultSchema` breakage
+in `packages/ui`.
+
+#### Scenario: Type-invalid test fixture fails the check
+
+- **WHEN** a test file constructs a fixture that does not satisfy the type it is passed as
+- **THEN** `npm run type-check` exits non-zero, naming that test file
+
+#### Scenario: No package excludes its own tests
+
+- **WHEN** each package's `tsconfig.json` (or the project the type check runs) is inspected
+- **THEN** none of them excludes that package's test files from type checking
+
+### Requirement: Lint is real and enforced
+
+The repository SHALL provide a working lint setup — a configuration and the tools it needs — exposed
+through a root `lint` script and run by the workflow. A package SHALL NOT declare a `lint` or
+`format` script that cannot execute.
+
+`packages/web` declares both today while neither `eslint` nor `prettier` is installed and no
+configuration exists anywhere in the repository. A script that exits with a "command not found"
+class of error is worse than no script: it reads as a gate that exists.
+
+#### Scenario: Root lint runs
+
+- **WHEN** `npm run lint` is run at the repository root on a clean checkout after `npm ci`
+- **THEN** the linter executes and reports results
+
+#### Scenario: Lint failure fails the workflow
+
+- **WHEN** the linter reports an error
+- **THEN** the workflow is marked failed
+
+#### Scenario: No unrunnable script is declared
+
+- **WHEN** any workspace's `package.json` declares a `lint` or `format` script
+- **THEN** that script executes successfully on a clean checkout after `npm ci`
+
+### Requirement: The Kotlin suite runs in CI
+
+The workflow SHALL run `packages/intellij`'s Gradle test suite on JDK 17, in a job separate from the
+Node gates.
+
+`packages/intellij` re-implements the core scanning rules in Kotlin (`ArtifactDiscovery.kt`,
+`SchemaOrder.kt`, `TaskParser.kt`), with its own tests under `src/test/kotlin`. Those rules are
+aligned with the TypeScript ones by convention only — nothing links them — so the Kotlin suite is
+the only thing that observes a divergence.
+
+#### Scenario: Gradle tests run
+
+- **WHEN** the workflow runs
+- **THEN** `./gradlew test` executes in `packages/intellij` on JDK 17
+
+#### Scenario: Kotlin test failure fails the workflow
+
+- **WHEN** a Kotlin test fails
+- **THEN** the workflow is marked failed
+
+### Requirement: The composite action is smoke-tested
+
+The workflow SHALL invoke the composite action defined by `action.yml` against this repository, with
+badge generation enabled, and SHALL assert that the files named by the `html-path` and `badges-path`
+outputs exist and are non-empty.
+
+`action.yml` is the only shipped artifact with no test coverage, and it fails silently: moving
+`@spekjs/ui`'s build from `prepare` to `prepublishOnly` removed the action's only source of ui
+`dist` and the Marketplace action was broken for a full day with nothing raising an alarm. Asserting
+that the outputs merely have values is not sufficient — a step output is set whether or not the
+build produced anything.
+
+#### Scenario: Action produces the HTML
+
+- **WHEN** the smoke job runs the action against this repository
+- **THEN** the file at the `html-path` output exists and is non-empty
+
+#### Scenario: Action produces badges
+
+- **WHEN** the smoke job runs the action with `generate-badges: "true"`
+- **THEN** the directory at the `badges-path` output exists and contains at least one badge file
+
+#### Scenario: Broken build chain fails the job
+
+- **WHEN** the action's build chain stops producing a workspace package's `dist`
+- **THEN** the smoke job fails rather than reporting success with an empty output
+
+### Requirement: The gates are runnable locally by the same commands
+
+Every gate the workflow runs SHALL be invocable locally through a documented root npm script, and
+the workflow SHALL invoke those same scripts rather than reimplementing a gate inline.
+
+A gate that only exists inside a workflow file cannot be reproduced by a contributor before pushing,
+and drifts from what the scripts do.
+
+#### Scenario: Contributor reproduces CI locally
+
+- **WHEN** a contributor runs the documented root scripts for test, type check, lint, and build
+- **THEN** they exercise the same gates the workflow runs
+
+#### Scenario: Gates are documented
+
+- **WHEN** a contributor reads `CONTRIBUTING.md`
+- **THEN** it names the commands that must pass before opening a pull request

--- a/openspec/changes/add-ci-and-npm-publish-automation/specs/continuous-integration/spec.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/specs/continuous-integration/spec.md
@@ -25,20 +25,34 @@ consumers.
 - **WHEN** any gate — test, type check, lint, or build — fails
 - **THEN** the workflow is marked failed
 
-### Requirement: Core is built before any gate that resolves it
+### Requirement: Every workspace package resolved through its dist is built before the gates
 
-The workflow SHALL build `@spekjs/core` after installing dependencies and before running the type
-check or any build that imports it.
+The workflow SHALL build **both** `@spekjs/core` and `@spekjs/ui` after installing dependencies and
+before running the type check or any build that imports them. It SHALL NOT assume that installing
+dependencies produced either one.
 
-`@spekjs/core`'s package entry is `dist/`, so `@spekjs/web` and `@spekjs/ui` type-check against
-`packages/core/dist/*.d.ts` rather than core's sources. On a fresh checkout with no core build, the
-type check reports errors that have nothing to do with the change under test.
+Both packages' entry points are `dist/`, so `@spekjs/web` type-checks against
+`packages/core/dist/*.d.ts` and `packages/ui/dist/*.d.ts` rather than against their sources. Neither
+`dist` survives a fresh `npm ci`: core's build is on `prepare`, and ui's is deliberately on
+`prepublishOnly`, because a `prepare` hook would run before npm creates the workspace symlinks and
+take the whole install down (see `ui-package`).
+
+The failure is invisible to local runs, where a `dist` from an earlier build is always present, and
+it does not name its cause — it surfaces as `TS2307: Cannot find module '@spekjs/ui'` plus a spray
+of implicit-`any` errors in the files that imported it.
 
 #### Scenario: Fresh runner checkout
 
-- **WHEN** the workflow runs on a runner with no pre-existing `packages/core/dist`
-- **THEN** `@spekjs/core` is built before the type check runs
+- **WHEN** the workflow runs on a runner with no pre-existing `packages/core/dist` or
+  `packages/ui/dist`
+- **THEN** both packages are built before the type check runs
 - **AND** the type check reports only errors attributable to the checked-out code
+
+#### Scenario: A newly added workspace package resolved through dist
+
+- **WHEN** a workspace package that resolves through a built `dist` is added and imported by another
+  package that the gates check
+- **THEN** the workflow builds it before the gates, rather than relying on an install-time hook
 
 ### Requirement: The type check covers every TypeScript source in the repository
 

--- a/openspec/changes/add-ci-and-npm-publish-automation/specs/npm-package-cicd/spec.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/specs/npm-package-cicd/spec.md
@@ -1,0 +1,152 @@
+## ADDED Requirements
+
+### Requirement: Publishing is triggered by a version difference against the registry
+
+The repository SHALL provide a GitHub Actions workflow that, on every `push` to `master`, compares
+each publishable package's declared `version` against the version published on the npm registry, and
+publishes that package when the two differ.
+
+`@spekjs/core` and `@spekjs/ui` SHALL be evaluated independently: one may publish while the other
+does not.
+
+The trigger is the version field rather than a dedicated tag because the version bump is already a
+deliberate, reviewed act performed by the release flow; requiring a second signal adds a step that
+can be forgotten without adding information.
+
+#### Scenario: Version differs from the registry
+
+- **WHEN** a commit lands on `master` in which `packages/core/package.json` declares a version not
+  present on the registry
+- **THEN** `@spekjs/core` is published at that version
+
+#### Scenario: Packages evaluated independently
+
+- **WHEN** only `@spekjs/ui`'s version differs from the registry
+- **THEN** `@spekjs/ui` is published and `@spekjs/core` is not
+
+#### Scenario: Already-published version is skipped quietly
+
+- **WHEN** a commit lands on `master` in which a package's declared version is already on the
+  registry
+- **THEN** that package is not published
+- **AND** the workflow succeeds rather than failing
+
+The skip must not fail. Most pushes to `master` change neither version, so a workflow that errors on
+"already published" would report a red `master` as its normal state, and a genuine failure would be
+indistinguishable from the noise.
+
+### Requirement: Publishing authenticates through OIDC, not a stored token
+
+The workflow SHALL authenticate to the npm registry using npm Trusted Publishing (OIDC). It SHALL
+NOT read a long-lived npm token from repository secrets.
+
+The job SHALL request the `id-token: write` permission, and SHALL ensure an npm CLI new enough to
+perform a trusted publish before invoking `npm publish` — the Node version pinned by `.nvmrc` ships
+an npm older than the minimum, so relying on the bundled npm fails.
+
+Trusted publishing attaches a provenance attestation automatically. Both packages already declare
+the `repository` URL and `directory` that provenance requires.
+
+#### Scenario: No npm token in the repository
+
+- **WHEN** the repository's secrets and workflow files are inspected
+- **THEN** no npm authentication token is stored or referenced
+
+#### Scenario: Publish carries provenance
+
+- **WHEN** a package is published by the workflow
+- **THEN** the published version carries a provenance attestation linking it to the workflow run and
+  commit that produced it
+
+#### Scenario: npm CLI too old to publish
+
+- **WHEN** the workflow runs on a Node version whose bundled npm predates trusted publishing support
+- **THEN** the workflow installs a new enough npm before publishing, rather than failing at the
+  publish step
+
+### Requirement: The publishing workflow's filename is part of its configuration
+
+The publishing workflow's filename SHALL be treated as configuration shared with the npm registry
+and SHALL NOT be renamed without re-registering it. The repository SHALL record this constraint
+where someone renaming the file would encounter it.
+
+A trusted publisher is registered on npmjs.com against a specific repository *and workflow
+filename*, matched exactly. Renaming the file leaves a workflow that still runs, still resolves the
+version difference, and fails only at the authentication step — with no indication that a rename
+caused it.
+
+#### Scenario: Constraint is discoverable at the file
+
+- **WHEN** a maintainer opens the publishing workflow
+- **THEN** the file states that its name is registered with the npm registry and must not be changed
+  without re-registering
+
+### Requirement: A successful publish creates a release tag
+
+On a successful publish, the workflow SHALL create and push an annotated tag naming the package and
+the published version, distinct from the product `v*` tag namespace — `core-vX.Y.Z` for
+`@spekjs/core` and `ui-vX.Y.Z` for `@spekjs/ui`.
+
+Neither package line has any tag today, so "what changed between core 1.3.0 and 1.4.0" cannot be
+answered from the repository; the only available anchor is a `chore(npm): publish …` commit-message
+convention, which nothing enforces.
+
+The repository SHALL also carry tags for the versions published before this workflow existed, so the
+tags describe the entire published history rather than starting mid-stream.
+
+#### Scenario: Tag created on publish
+
+- **WHEN** `@spekjs/core` is published at 1.4.1 by the workflow
+- **THEN** an annotated tag `core-v1.4.1` is created on the published commit and pushed to origin
+
+#### Scenario: No tag when nothing is published
+
+- **WHEN** the workflow skips a package because its version is already on the registry
+- **THEN** no tag is created for that package
+
+#### Scenario: Historical versions are tagged
+
+- **WHEN** the tags are listed after this change is implemented
+- **THEN** every previously published version of both packages has a corresponding tag on the commit
+  that published it
+
+#### Scenario: Product tags are unaffected
+
+- **WHEN** package tags are created
+- **THEN** the product `v*` tag namespace is untouched, and no existing tag is moved or deleted
+
+### Requirement: The version bump is decided by the release flow, not derived from commit messages
+
+The choice of version increment SHALL be made by the release flow — which reads the archived
+changes' stated impact — and SHALL NOT be inferred from commit message prefixes.
+
+This repository's own history shows the inference is unreliable. `@spekjs/core` 1.3.0 came from a
+single `fix(core,ui):` commit that added the `./graph-node-id` export subpath, and 1.4.0 from three
+`fix:` / `test:` commits that changed `TaskItem.text`'s semantics for consumers. A
+conventional-commit rule would have published 1.2.1 and 1.3.1 — under-bumping two of the last four
+core releases. A published version cannot be withdrawn, so an under-bump is corrected only by
+publishing again.
+
+This is why the project convention requires a change that affects registry consumers — a new public
+export, a behavior change, additive-so-minor-not-patch — to record that in its proposal or design
+for whoever cuts the release.
+
+#### Scenario: Release flow covers the package line
+
+- **WHEN** the release flow runs
+- **THEN** it checks, for each publishable package, whether that package's sources changed since its
+  last release tag
+- **AND** for each package that changed, it decides the version increment, updates that package's
+  CHANGELOG, and bumps the version
+
+#### Scenario: Additive change is not published as a patch
+
+- **WHEN** a change adds a new public export or alters behavior observable by a registry consumer,
+  under a commit whose prefix is `fix:`
+- **THEN** the release flow selects a minor increment, on the evidence in the change's artifacts
+  rather than the commit prefix
+
+#### Scenario: No package changes since the last release
+
+- **WHEN** neither package's sources changed since its last release tag
+- **THEN** the release flow bumps neither package and the publish workflow has nothing to do

--- a/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
@@ -59,9 +59,9 @@
 
 ## 5. Backfill the package release tags
 
-- [ ] 5.1 Create the twelve annotated tags on the commits listed in the design's backfill table
+- [x] 5.1 Create the twelve annotated tags on the commits listed in the design's backfill table
       (`core-v1.0.0` … `core-v1.4.0`, `ui-v1.0.0` … `ui-v1.2.0`; `2e65a11` carries two).
-- [ ] 5.2 Verify each tagged commit's `packages/<pkg>/package.json` declares the version the tag
+- [x] 5.2 Verify each tagged commit's `packages/<pkg>/package.json` declares the version the tag
       names, and that no existing tag was moved or deleted.
 - [ ] 5.3 Push the tags to origin.
 
@@ -70,52 +70,52 @@
 - [ ] 6.1 Register a trusted publisher for `@spekjs/core` and `@spekjs/ui` on npmjs.com, pointing at
       `spekhq/spek` and the workflow filename `npm-publish.yml`. **Maintainer action outside the
       repository; publishing cannot authenticate until it is done.**
-- [ ] 6.2 Create `.github/workflows/npm-publish.yml` on `push` to `master`, with
+- [x] 6.2 Create `.github/workflows/npm-publish.yml` on `push` to `master`, with
       `id-token: write` + `contents: write` and a concurrency group. Open the file with a comment
       stating that its filename is registered with the npm registry and must not be renamed without
       re-registering.
-- [ ] 6.3 Run the gates in the job before publishing: `npm ci` → `npm run build:core` → `npm test` →
+- [x] 6.3 Run the gates in the job before publishing: `npm ci` → `npm run build:core` → `npm test` →
       `npm run type-check`. Do not chain on `ci.yml` via `workflow_run`.
-- [ ] 6.4 Install npm ≥ 11.5.1 after `setup-node` — the Node pinned by `.nvmrc` bundles npm 10.9.4,
+- [x] 6.4 Install npm ≥ 11.5.1 after `setup-node` — the Node pinned by `.nvmrc` bundles npm 10.9.4,
       which predates trusted publishing.
-- [ ] 6.5 For each package, compare the declared version against the registry and publish only on a
+- [x] 6.5 For each package, compare the declared version against the registry and publish only on a
       difference; an already-published version exits successfully without publishing.
-- [ ] 6.6 On a successful publish, create and push the matching `core-vX.Y.Z` / `ui-vX.Y.Z`
+- [x] 6.6 On a successful publish, create and push the matching `core-vX.Y.Z` / `ui-vX.Y.Z`
       annotated tag. Create no tag when the package was skipped.
-- [ ] 6.7 Keep the workflow flat — no reusable-workflow indirection, which breaks npm's OIDC
+- [x] 6.7 Keep the workflow flat — no reusable-workflow indirection, which breaks npm's OIDC
       filename validation.
 - [ ] 6.8 Verify end to end with a deliberate patch release of one package: the publish succeeds,
       the registry shows a provenance attestation, and the tag lands on the right commit.
 
 ## 7. Extend the release skill to the package line
 
-- [ ] 7.1 Add a step to `.agents/skills/release/SKILL.md` that, for each of `@spekjs/core` and
+- [x] 7.1 Add a step to `.agents/skills/release/SKILL.md` that, for each of `@spekjs/core` and
       `@spekjs/ui`, diffs `packages/<pkg>/src` against that package's last release tag and reports
       whether a release is due.
-- [ ] 7.2 Specify how the increment is decided: from the archived changes' stated impact (a new
+- [x] 7.2 Specify how the increment is decided: from the archived changes' stated impact (a new
       public export, a behavior change observable by a consumer), never from commit prefixes. Cite
       core 1.3.0 and 1.4.0 as the worked examples of why.
-- [ ] 7.3 Specify the outputs of the step — that package's CHANGELOG updated, its version bumped,
+- [x] 7.3 Specify the outputs of the step — that package's CHANGELOG updated, its version bumped,
       and a `chore(npm): publish @spekjs/<pkg>@X.Y.Z` commit written — and that CI publishes from
       there, so the skill no longer runs `npm publish` locally.
-- [ ] 7.4 Add a guardrail covering the case where neither package changed: bump neither, and say so.
+- [x] 7.4 Add a guardrail covering the case where neither package changed: bump neither, and say so.
 
 ## 8. Update the documentation the gates change
 
-- [ ] 8.1 Update `CONTRIBUTING.md` to name the commands that must pass before opening a pull
+- [x] 8.1 Update `CONTRIBUTING.md` to name the commands that must pass before opening a pull
       request, and to state that CI runs them.
-- [ ] 8.2 Update `CLAUDE.md`: `action.yml` is no longer untested (revise the "zero test coverage"
+- [x] 8.2 Update `CLAUDE.md`: `action.yml` is no longer untested (revise the "zero test coverage"
       section to describe the smoke job and what it does not cover), record the npm publish flow and
       the workflow-filename trap, and correct the "Development Commands" list where `type-check` and
       `lint` now mean something different.
-- [ ] 8.3 Update the `README` / `README.zh-TW` development sections if they name the old
+- [x] 8.3 Update the `README` / `README.zh-TW` development sections if they name the old
       `type-check` scope.
 
 ## 9. Verify
 
-- [ ] 9.1 Run `npm run build:core && npm test && npm run type-check && npm run lint && npm run build`
+- [x] 9.1 Run `npm run build:core && npm test && npm run type-check && npm run lint && npm run build`
       locally from a clean `npm ci` and confirm all pass.
-- [ ] 9.2 Run `./gradlew test` in `packages/intellij` and confirm it passes.
+- [x] 9.2 Run `./gradlew test` in `packages/intellij` and confirm it passes.
 - [ ] 9.3 Open a pull request and confirm every job reports, including the smoke job.
 - [ ] 9.4 Confirm a pull request that introduces a type error in a test file is caught — the hole
       this change exists to close.

--- a/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
@@ -54,8 +54,10 @@
       on the output values being set.
 - [x] 4.3 Verify the job fails when the action's build chain is broken — temporarily remove the
       `Build @spekjs/ui` step from a scratch branch, confirm the job goes red, then restore it.
-- [ ] 4.4 Observe whether the pinned `spek-version` resolves on a fork pull request. If it does not,
+- [x] 4.4 Observe whether the pinned `spek-version` resolves on a fork pull request. If it does not,
       restrict the smoke job to `push: master` and record why in the workflow file.
+      *Observed on a same-repo PR (#36): resolves, smoke job passes. A fork PR has still not run —
+      recorded in design.md as the remaining unknown, with the `push: master` fallback.*
 
 ## 5. Backfill the package release tags
 
@@ -63,11 +65,11 @@
       (`core-v1.0.0` … `core-v1.4.0`, `ui-v1.0.0` … `ui-v1.2.0`; `2e65a11` carries two).
 - [x] 5.2 Verify each tagged commit's `packages/<pkg>/package.json` declares the version the tag
       names, and that no existing tag was moved or deleted.
-- [ ] 5.3 Push the tags to origin.
+- [x] 5.3 Push the tags to origin.
 
 ## 6. Add the npm publish workflow
 
-- [ ] 6.1 Register a trusted publisher for `@spekjs/core` and `@spekjs/ui` on npmjs.com, pointing at
+- [x] 6.1 Register a trusted publisher for `@spekjs/core` and `@spekjs/ui` on npmjs.com, pointing at
       `spekhq/spek` and the workflow filename `npm-publish.yml`. **Maintainer action outside the
       repository; publishing cannot authenticate until it is done.**
 - [x] 6.2 Create `.github/workflows/npm-publish.yml` on `push` to `master`, with

--- a/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
@@ -118,6 +118,8 @@
 - [x] 9.1 Run `npm run build:core && npm test && npm run type-check && npm run lint && npm run build`
       locally from a clean `npm ci` and confirm all pass.
 - [x] 9.2 Run `./gradlew test` in `packages/intellij` and confirm it passes.
-- [ ] 9.3 Open a pull request and confirm every job reports, including the smoke job.
-- [ ] 9.4 Confirm a pull request that introduces a type error in a test file is caught — the hole
+- [x] 9.3 Open a pull request and confirm every job reports, including the smoke job.
+- [x] 9.4 Confirm a pull request that introduces a type error in a test file is caught — the hole
       this change exists to close.
+      *Verified on throwaway PR #37 (closed unmerged): `Test` passed 267 assertions, `Type check`
+      then failed with the expected `TS2741`.*

--- a/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
+++ b/openspec/changes/add-ci-and-npm-publish-automation/tasks.md
@@ -1,0 +1,121 @@
+## 1. Make the type check cover the repository
+
+- [x] 1.1 Add `tsconfig.test.json` to `packages/core` and `packages/ui`, each extending that
+      package's `tsconfig.json`, clearing the test `exclude` and setting `noEmit: true`. Leave the
+      build `tsconfig.json` untouched — it emits into the published `dist`.
+- [x] 1.2 Add a `tsconfig.scripts.json` at the repository root covering `scripts/*.ts` with
+      `noEmit: true`.
+- [x] 1.3 Add a `type-check` script to `packages/core`, `packages/ui`, and `packages/vscode`. For
+      core and ui it runs both the build config and the test config with `--noEmit`.
+- [x] 1.4 Change the root `type-check` script to run every workspace plus the scripts config,
+      replacing the current web-only invocation.
+- [x] 1.5 Resolve the stale root `tsconfig.json` (project references naming only core and web,
+      consumed by nothing) — repair it to match the current package set or remove it.
+- [x] 1.6 Fix the two `TS2741`s in `packages/core/src/aggregate.test.ts` (missing `vcs` on the
+      `WorktreeInfo` fixtures at lines 269-270).
+- [x] 1.7 Run `npm run build:core && npm run type-check` and fix everything it now reports. Note
+      that only core's tests were measured beforehand; `scripts/` has never been type-checked.
+- [x] 1.8 Verify `npm run build -w @spekjs/core` and `npm run build -w @spekjs/ui` still emit no
+      test file into `dist/`, and that `npm pack --dry-run` for each carries none.
+
+## 2. Add working lint
+
+- [x] 2.1 Install ESLint with `typescript-eslint` and `eslint-plugin-react-hooks` as root dev
+      dependencies. Do not add Prettier.
+- [x] 2.2 Run ESLint with the recommended baseline before writing the final config, to size the
+      violation backlog and decide which rules can land enabled.
+- [x] 2.3 Add a flat ESLint config at the repository root covering `packages/*/src`,
+      `packages/web/server`, and `scripts/`. Record a reason inline for any rule disabled to keep
+      the backlog manageable.
+- [x] 2.4 Fix the violations the enabled rule set reports.
+- [x] 2.5 Add a root `lint` script; make `packages/web`'s `lint` script functional and delete its
+      dead `format` script.
+- [x] 2.6 Verify `npm run lint` passes from a clean `npm ci`.
+
+## 3. Add the CI workflow
+
+- [x] 3.1 Create `.github/workflows/ci.yml` triggered on `pull_request` and `push` to `master`.
+- [x] 3.2 Add the Node job: `npm ci` → `npm run build:core` → `npm test` → `npm run type-check` →
+      `npm run lint` → `npm run build` → `npm run build:demo`. Invoke the root scripts rather than
+      reimplementing any gate inline. Build core before the type check.
+- [x] 3.3 Set `NODE_ENV=production` for the `build:demo` step so CI does not exercise a different
+      build than the one that ships.
+- [x] 3.4 Add the Kotlin job: JDK 17 (temurin) + `./gradlew test` in `packages/intellij`, running in
+      parallel with the Node job.
+- [x] 3.5 Confirm the workflow needs no write permissions and declare the minimum explicitly.
+
+## 4. Smoke-test the composite action in CI
+
+- [x] 4.1 Add a smoke job to `ci.yml` that invokes the action from `./` with
+      `generate-badges: "true"` and `spek-version: ${{ github.sha }}` — the default `master` would
+      test master's action implementation instead of the commit under test.
+- [x] 4.2 Assert the file at the `html-path` output exists and is non-empty, and that the
+      `badges-path` directory exists and holds at least one badge file. Assert on file contents, not
+      on the output values being set.
+- [x] 4.3 Verify the job fails when the action's build chain is broken — temporarily remove the
+      `Build @spekjs/ui` step from a scratch branch, confirm the job goes red, then restore it.
+- [ ] 4.4 Observe whether the pinned `spek-version` resolves on a fork pull request. If it does not,
+      restrict the smoke job to `push: master` and record why in the workflow file.
+
+## 5. Backfill the package release tags
+
+- [ ] 5.1 Create the twelve annotated tags on the commits listed in the design's backfill table
+      (`core-v1.0.0` … `core-v1.4.0`, `ui-v1.0.0` … `ui-v1.2.0`; `2e65a11` carries two).
+- [ ] 5.2 Verify each tagged commit's `packages/<pkg>/package.json` declares the version the tag
+      names, and that no existing tag was moved or deleted.
+- [ ] 5.3 Push the tags to origin.
+
+## 6. Add the npm publish workflow
+
+- [ ] 6.1 Register a trusted publisher for `@spekjs/core` and `@spekjs/ui` on npmjs.com, pointing at
+      `spekhq/spek` and the workflow filename `npm-publish.yml`. **Maintainer action outside the
+      repository; publishing cannot authenticate until it is done.**
+- [ ] 6.2 Create `.github/workflows/npm-publish.yml` on `push` to `master`, with
+      `id-token: write` + `contents: write` and a concurrency group. Open the file with a comment
+      stating that its filename is registered with the npm registry and must not be renamed without
+      re-registering.
+- [ ] 6.3 Run the gates in the job before publishing: `npm ci` → `npm run build:core` → `npm test` →
+      `npm run type-check`. Do not chain on `ci.yml` via `workflow_run`.
+- [ ] 6.4 Install npm ≥ 11.5.1 after `setup-node` — the Node pinned by `.nvmrc` bundles npm 10.9.4,
+      which predates trusted publishing.
+- [ ] 6.5 For each package, compare the declared version against the registry and publish only on a
+      difference; an already-published version exits successfully without publishing.
+- [ ] 6.6 On a successful publish, create and push the matching `core-vX.Y.Z` / `ui-vX.Y.Z`
+      annotated tag. Create no tag when the package was skipped.
+- [ ] 6.7 Keep the workflow flat — no reusable-workflow indirection, which breaks npm's OIDC
+      filename validation.
+- [ ] 6.8 Verify end to end with a deliberate patch release of one package: the publish succeeds,
+      the registry shows a provenance attestation, and the tag lands on the right commit.
+
+## 7. Extend the release skill to the package line
+
+- [ ] 7.1 Add a step to `.agents/skills/release/SKILL.md` that, for each of `@spekjs/core` and
+      `@spekjs/ui`, diffs `packages/<pkg>/src` against that package's last release tag and reports
+      whether a release is due.
+- [ ] 7.2 Specify how the increment is decided: from the archived changes' stated impact (a new
+      public export, a behavior change observable by a consumer), never from commit prefixes. Cite
+      core 1.3.0 and 1.4.0 as the worked examples of why.
+- [ ] 7.3 Specify the outputs of the step — that package's CHANGELOG updated, its version bumped,
+      and a `chore(npm): publish @spekjs/<pkg>@X.Y.Z` commit written — and that CI publishes from
+      there, so the skill no longer runs `npm publish` locally.
+- [ ] 7.4 Add a guardrail covering the case where neither package changed: bump neither, and say so.
+
+## 8. Update the documentation the gates change
+
+- [ ] 8.1 Update `CONTRIBUTING.md` to name the commands that must pass before opening a pull
+      request, and to state that CI runs them.
+- [ ] 8.2 Update `CLAUDE.md`: `action.yml` is no longer untested (revise the "zero test coverage"
+      section to describe the smoke job and what it does not cover), record the npm publish flow and
+      the workflow-filename trap, and correct the "Development Commands" list where `type-check` and
+      `lint` now mean something different.
+- [ ] 8.3 Update the `README` / `README.zh-TW` development sections if they name the old
+      `type-check` scope.
+
+## 9. Verify
+
+- [ ] 9.1 Run `npm run build:core && npm test && npm run type-check && npm run lint && npm run build`
+      locally from a clean `npm ci` and confirm all pass.
+- [ ] 9.2 Run `./gradlew test` in `packages/intellij` and confirm it passes.
+- [ ] 9.3 Open a pull request and confirm every job reports, including the smoke job.
+- [ ] 9.4 Confirm a pull request that introduces a type error in a test file is caught — the hole
+      this change exists to close.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,12 @@
         "packages/ui",
         "packages/web",
         "packages/vscode"
-      ]
+      ],
+      "devDependencies": {
+        "eslint": "^9.39.5",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "typescript-eslint": "^8.66.0"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",
@@ -922,6 +927,263 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1909,26 +2171,6 @@
         "text-table": "^0.2.0"
       }
     },
-    "node_modules/@textlint/linter-formatter/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
@@ -2179,6 +2421,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2284,6 +2533,291 @@
       "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.66.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.3",
@@ -2545,6 +3079,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2613,6 +3170,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -2932,6 +3496,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3508,6 +4082,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/default-browser": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
@@ -3944,6 +4525,223 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -3952,6 +4750,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -4065,6 +4873,20 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -4120,6 +4942,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4165,6 +5000,44 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -4430,6 +5303,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {
@@ -4730,6 +5616,33 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/index-to-position": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
@@ -4979,6 +5892,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4992,10 +5928,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5104,6 +6054,16 @@
         "prebuild-install": "^7.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5112,6 +6072,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -5385,6 +6359,22 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -5431,6 +6421,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5495,13 +6492,6 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
@@ -6474,9 +7464,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6554,6 +7544,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -6745,6 +7742,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
@@ -6764,6 +7811,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -6888,6 +7948,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -7039,6 +8109,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -7072,6 +8152,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -7172,26 +8262,6 @@
         "js-yaml": "^4.1.0",
         "json5": "^2.2.2",
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/rc-config-loader/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/react": {
@@ -7462,6 +8532,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -8312,6 +9392,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -8361,6 +9454,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -8413,6 +9519,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uc.micro": {
@@ -8594,6 +9724,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-join": {
@@ -9302,6 +10442,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -9435,6 +10585,19 @@
         "buffer-crc32": "~0.2.3"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -9447,7 +10610,7 @@
     },
     "packages/core": {
       "name": "@spekjs/core",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6"
@@ -9492,15 +10655,17 @@
     },
     "packages/vscode": {
       "name": "spek-vscode",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "license": "MIT",
       "devDependencies": {
         "@spekjs/core": "*",
+        "@types/node": "^22.10.0",
         "@types/vscode": "^1.85.0",
         "@vscode/vsce": "^3.0.0",
         "chokidar": "^5.0.0",
         "esbuild": "^0.24.0",
-        "fuse.js": "^7.0.0"
+        "fuse.js": "^7.0.0",
+        "typescript": "^5.7.0"
       },
       "engines": {
         "vscode": "^1.85.0"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,18 @@
     "build:web": "npm run build:ui && npm run build -w @spekjs/web",
     "build:webview": "npm run build:core && npm run build:ui && npm run build:webview -w @spekjs/web",
     "build:vscode": "npm run build -w spek-vscode",
-    "type-check": "npm run type-check -w @spekjs/web",
+    "type-check": "npm run type-check -w @spekjs/core && npm run type-check -w @spekjs/ui && npm run type-check -w @spekjs/web && npm run type-check -w spek-vscode && tsc -p tsconfig.scripts.json",
+    "lint": "eslint packages/core/src packages/ui/src packages/web/src packages/web/server packages/vscode/src scripts --max-warnings 0",
     "build:demo": "npm run build -w @spekjs/core && npm run build:ui && tsx scripts/build-demo.ts",
     "build:badges": "npm run build -w @spekjs/core && tsx scripts/generate-badges.ts --repo-dir . --output-dir docs/badges",
     "build:intellij": "npm run build:core && npm run build:ui && npm run build:intellij -w @spekjs/web",
     "version": "node -e \"const p=require('./packages/vscode/package.json');p.version=require('./package.json').version;require('fs').writeFileSync('./packages/vscode/package.json',JSON.stringify(p,null,2)+'\\n')\" && node -e \"const v=require('./package.json').version;const f='./packages/intellij/gradle.properties';const c=require('fs').readFileSync(f,'utf8').replace(/pluginVersion = .*/,'pluginVersion = '+v);require('fs').writeFileSync(f,c)\" && git add packages/vscode/package.json packages/intellij/gradle.properties",
     "build:ui": "npm run build -w @spekjs/ui",
     "test": "npm test -w @spekjs/core && npm test -w @spekjs/ui && npm test -w @spekjs/web"
+  },
+  "devDependencies": {
+    "eslint": "^9.39.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "typescript-eslint": "^8.66.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "build": "rm -rf dist && tsc",
     "prepare": "tsc",
     "dev": "tsc --watch",
+    "type-check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
     "test": "node --import tsx --test src/*.test.ts"
   },
   "dependencies": {

--- a/packages/core/src/aggregate.test.ts
+++ b/packages/core/src/aggregate.test.ts
@@ -266,8 +266,8 @@ test("scanOpenSpecAggregated: main's UNCOMMITTED advance competes in a live cont
 test("pickActiveWinners: a worktree whose divergence check fails does not shadow main", async () => {
   // 注入一個永遠回空集合的 divergence provider，模擬對該 worktree 的 git 指令失敗。
   // fork 持有 foo 但被判為未分歧 → main 保留 foo（不因 git 失敗而錯顯 fork 的繼承副本）。
-  const mainWt: WorktreeInfo = { path: "/repo", branch: "main", head: "aaa", isMain: true, isBare: false, key: "m" };
-  const fork: WorktreeInfo = { path: "/repo-x", branch: "wx", head: "bbb", isMain: false, isBare: false, key: "x" };
+  const mainWt: WorktreeInfo = { path: "/repo", branch: "main", head: "aaa", isMain: true, isBare: false, key: "m", vcs: "git" };
+  const fork: WorktreeInfo = { path: "/repo-x", branch: "wx", head: "bbb", isMain: false, isBare: false, key: "x", vcs: "git" };
   const failing = async () => new Set<string>();
 
   const winners = await pickActiveWinners(

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  // Type-checks the test files that tsconfig.json deliberately excludes.
+  //
+  // The exclude in tsconfig.json cannot simply be dropped: that config is also what `npm run build`
+  // uses, it emits into `dist`, and `files: ["dist"]` publishes it — so a test file included there
+  // ends up in the tarball consumers download. This config exists purely to check them, never to
+  // emit. See openspec/specs/continuous-integration.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
     "build:css": "cp src/styles.css dist/styles.css",
     "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
+    "type-check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",
     "test": "node --import tsx --test \"src/**/__tests__/*.test.ts\""
   },
   "dependencies": {

--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  // Type-checks the test files that tsconfig.json deliberately excludes.
+  //
+  // The exclude in tsconfig.json cannot simply be dropped: that config is also what `npm run build`
+  // uses, it emits into `dist`, and `files: ["dist"]` publishes it — so a test file included there
+  // ends up in the tarball consumers download. This config exists purely to check them, never to
+  // emit. See openspec/specs/continuous-integration.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -107,6 +107,7 @@
     "vscode:prepublish": "npm run build",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
     "watch": "npm run build -- --watch",
+    "type-check": "tsc -p tsconfig.json",
     "package": "vsce package --no-dependencies",
     "publish": "vsce publish --no-dependencies"
   },
@@ -115,7 +116,9 @@
     "esbuild": "^0.24.0",
     "@vscode/vsce": "^3.0.0",
     "@spekjs/core": "*",
+    "@types/node": "^22.10.0",
     "chokidar": "^5.0.0",
-    "fuse.js": "^7.0.0"
+    "fuse.js": "^7.0.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 import { SpekPanel } from "./panel";
 import { SpecsTreeProvider, ChangesTreeProvider } from "./tree-provider";
@@ -80,8 +82,6 @@ function getWorkspacePath(): string | undefined {
 
 function hasOpenSpecDir(workspacePath: string): boolean {
   try {
-    const fs = require("fs");
-    const path = require("path");
     const openspecDir = path.join(workspacePath, "openspec");
 
     // 先檢查 config.yaml

--- a/packages/vscode/src/panel.ts
+++ b/packages/vscode/src/panel.ts
@@ -205,7 +205,6 @@ export class SpekPanel {
       return `<!DOCTYPE html><html><body><h1>spek webview assets not found</h1><p>Run build first.</p></body></html>`;
     }
 
-    const html = fs.readFileSync(indexPath, "utf-8");
     const nonce = getNonce();
     const webview = this.panel.webview;
     const cspSource = webview.cspSource;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,8 +10,7 @@
     "build:intellij": "vite build --config vite.intellij.config.ts",
     "type-check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.server.json --noEmit",
     "test": "node --import tsx --test \"src/**/*.test.ts\"",
-    "lint": "eslint src server --ext .ts,.tsx",
-    "format": "prettier --write src server"
+    "lint": "eslint src server --max-warnings 0"
   },
   "dependencies": {
     "@spekjs/core": "*",

--- a/packages/web/src/components/SearchDialog.tsx
+++ b/packages/web/src/components/SearchDialog.tsx
@@ -75,12 +75,16 @@ export function SearchDialog({ open, onClose }: SearchDialogProps) {
   const navigate = useNavigate();
   const { results, loading } = useSearch(query);
 
-  // 按類型分組
-  const specResults = results.filter((r) => r.type === "spec");
-  const changeResults = results.filter((r) => r.type === "change");
-
-  const filteredSpecResults = typeFilter === "change" ? [] : specResults;
-  const filteredChangeResults = typeFilter === "spec" ? [] : changeResults;
+  // 按類型分組。兩個清單各自 memo：直接在 render 中算會每次產生新陣列 identity，
+  // 讓下面的 flatResults memo 每次都重算，等於沒有 memo。
+  const filteredSpecResults = useMemo(
+    () => (typeFilter === "change" ? [] : results.filter((r) => r.type === "spec")),
+    [results, typeFilter]
+  );
+  const filteredChangeResults = useMemo(
+    () => (typeFilter === "spec" ? [] : results.filter((r) => r.type === "change")),
+    [results, typeFilter]
+  );
   const flatResults = useMemo(
     () => [...filteredSpecResults, ...filteredChangeResults],
     [filteredSpecResults, filteredChangeResults]

--- a/packages/web/src/hooks/useOpenSpec.ts
+++ b/packages/web/src/hooks/useOpenSpec.ts
@@ -14,7 +14,6 @@ import type {
   SpecInfo,
   SpecDetail,
   SpecVersionContent,
-  HistoryEntry as SpecHistoryEntry,
   ChangeInfo,
   ChangesData,
   ChangeDetail,
@@ -62,7 +61,6 @@ function useAsyncData<T>(
     loading: !!fetcher,
     error: null,
   });
-  const isRefresh = useRef(false);
   const prevRefreshKey = useRef(refreshKey);
 
   useEffect(() => {

--- a/packages/web/src/hooks/useScrollspy.ts
+++ b/packages/web/src/hooks/useScrollspy.ts
@@ -5,8 +5,14 @@ import { activeHeadingId } from "../utils/scrollspy";
 export function useScrollspy(ids: string[]): string | null {
   const [activeId, setActiveId] = useState<string | null>(null);
 
+  // 依「內容」而非陣列 identity 訂閱：呼叫端每次 render 都給新陣列，直接相依 ids 會每次
+  // 重新掛卸監聽。id 是 slugifyHeading 的輸出（非字母數字皆轉為 -），不可能含有 "|"，
+  // 故 join/split 為無損往返，effect 內只需相依這個 key。
+  const idsKey = ids.join("|");
+
   useEffect(() => {
-    if (ids.length === 0) {
+    const idList = idsKey ? idsKey.split("|") : [];
+    if (idList.length === 0) {
       setActiveId(null);
       return;
     }
@@ -14,7 +20,7 @@ export function useScrollspy(ids: string[]): string | null {
     const computeActive = () => {
       // 與錨點捲動同一條偏移線（sticky header 底邊），highlight 才會對上實際置頂的 heading
       const threshold = scrollOffset();
-      const tops = ids.map((id) => {
+      const tops = idList.map((id) => {
         const el = document.getElementById(id);
         return { id, top: el ? el.getBoundingClientRect().top : null };
       });
@@ -38,7 +44,7 @@ export function useScrollspy(ids: string[]): string | null {
       window.removeEventListener("resize", onScroll);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [ids.join("|")]);
+  }, [idsKey]);
 
   return activeId;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "files": [],
-  "references": [
-    { "path": "packages/core" },
-    { "path": "packages/web" }
-  ]
-}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,23 @@
+{
+  // Type-checks scripts/*.ts, which no other tsconfig in the repository names — they were the only
+  // TypeScript here that nothing checked, and they are what the composite action and the deployed
+  // demo page actually execute.
+  //
+  // These scripts import "../packages/core/dist/index.js" directly, so `npm run build:core` must
+  // have run before this config can resolve them. See openspec/specs/continuous-integration.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["scripts"]
+}


### PR DESCRIPTION
Closes #16.

## Why

Nothing ran tests, type checks, or lint automatically — all three existing workflows publish or deploy on a tag, none run on `pull_request`. Every gate was a command a human remembered to type.

That was hiding a live defect: `packages/core/src/aggregate.test.ts` failed to type-check with two `TS2741`s while `npm test` reported 60/60 passing. Two holes lined up — a root `type-check` covering only `@spekjs/web`, and package tsconfigs excluding their own tests while the suites run through `tsx`, which strips types without checking them.

Separately, `@spekjs/core` / `@spekjs/ui` were published entirely by hand, and neither version line had a single git tag.

## What's here

**Gates** — `ci.yml` on `pull_request` + `push:[master]`: Node gates (test, type check, lint, build, `build:demo` under `NODE_ENV=production`), the Kotlin suite on JDK 17, and a smoke test of the composite action.

**Type check** now covers core / ui / web / vscode **and `scripts/`** — `build-demo.ts` and `generate-badges.ts` were named by no tsconfig at all, despite being what the action and the demo page execute. Test files are included via a per-package `tsconfig.test.json` rather than by deleting the `exclude`: those configs also drive the build, which emits into the published `dist`, so deleting it would ship compiled tests to consumers.

**Lint** is real for the first time. `packages/web` declared `lint` and `format` scripts while neither eslint nor prettier was installed and no config existed anywhere. Prettier is deliberately not added — it would rewrite nearly every file for no defect caught.

**Publishing** — `npm-publish.yml` publishes each package when its declared version differs from the registry, via Trusted Publishing (OIDC, no stored token, provenance automatic), then tags `core-vX.Y.Z` / `ui-vX.Y.Z`. An already-published version is a quiet skip, not a failure. Twelve backfill tags cover every version already on the registry.

The version *decision* stays in the `release` skill, read from the archived changes' Impact — never from commit prefixes, which get it wrong about half the time here (core 1.3.0 and 1.4.0 were both `fix:` commits that warranted a minor).

## Bugs the new gates caught

- `vscode/panel.ts` — `getHtml()` read `index.webview.html` on every render and discarded it
- `web/SearchDialog.tsx` — the `flatResults` memo recomputed every render, its deps being freshly-built arrays
- `web/useOpenSpec.ts` — an unused ref and an unused type import
- `web/useScrollspy.ts` — effect now keyed on the joined ids instead of the unstable array (behavior identical; slugs cannot contain the separator)
- `vscode/extension.ts` — two `require()` calls in a file already using ESM imports

## Notes for review

- The smoke job pins `spek-version: ${{ github.sha }}`. The action checks out `spekhq/spek` at that ref and builds from *that* copy, so the default `master` would test master's implementation and go green on a PR that breaks the action. **Whether this resolves for a fork PR is the one open question** — if it doesn't, the fallback is restricting the job to `push: master`.
- `npm-publish.yml`'s **filename is registered with npm and matched exactly**. Renaming it leaves a workflow that runs, resolves the version difference, and fails only at authentication, naming no cause.
- Gates run inside the publish job rather than chaining on `ci.yml` via `workflow_run` — that trigger evaluates the workflow file from the default branch rather than the triggering commit, and getting its coupling wrong publishes on a red build, which cannot be undone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgfFLCcVjPxZJmMspbY4Bu