### PR TITLE
docs(claude): collect the three names that are configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,22 @@ spek — an OpenSpec content viewer. Four delivery surfaces plus one CI helper:
 
 The repo is **`spekhq/spek`**; the npm scope is **`@spekjs`** (an org name ≠ npm scope is normal — don't "fix" the mismatch).
 
+## Three things whose *names* are configuration — renaming any of them fails silently
+
+Each is referenced by something outside the file that holds it, matched by exact string, with no error when the
+match breaks. Rename only alongside updating the other side.
+
+| Name | Referenced by | What a rename does |
+|---|---|---|
+| `ci.yml`'s job names — `Node gates`, `Kotlin gates`, `Composite action smoke test` | `master`'s branch protection (required status checks) | PRs sit at **pending forever**, waiting on a check that will never report. Reads like CI is down, not like a config error |
+| `npm-publish.yml` (the filename) | npm's trusted publisher registration for both packages | The workflow still runs and still resolves the version difference; it fails only at authentication, naming no cause |
+| `action.yml`'s build chain steps | nothing — it is the *absence* of a reference that bites | Outputs stay populated while the files behind them are empty or missing (see below) |
+
+Branch protection on `master` requires those three checks with `strict: true` (a PR must be up to date before
+merging), does **not** require reviews, and leaves `enforce_admins` off — deliberately, because the `release` skill
+pushes the `npm version` commit straight to `master` and a locally-created commit can never have passed a required
+check. Turning admin enforcement on breaks `/release`.
+
 ## action.yml: smoke-tested only — read before touching the build chain
 
 CI runs a smoke job (`action-smoke` in `ci.yml`) that invokes the composite action against this repo with
@@ -285,10 +301,8 @@ GET /api/openspec/search?dir=...&q=...              # full-text search
   - **`@spekjs/*` publishing is automated; the version decision is not.** CI publishes a package when its declared
     version differs from the registry (`.github/workflows/npm-publish.yml`, on `push:[master]`), authenticating via
     npm Trusted Publishing (OIDC — no token in repo secrets) and creating a `core-vX.Y.Z` / `ui-vX.Y.Z` tag on
-    success. Never run `npm publish` locally and never hand-create those tags. **The workflow's filename is
-    registered with npm and matched exactly — renaming `npm-publish.yml` leaves a workflow that still runs, still
-    resolves the version difference, and fails only at authentication, with nothing naming the cause.** The bump
-    itself is chosen by the `release` skill from the archived changes' Impact, never from commit prefixes: core
+    success. Never run `npm publish` locally and never hand-create those tags. Its filename is configuration — see
+    the renaming table at the top of this file. The bump itself is chosen by the `release` skill from the archived changes' Impact, never from commit prefixes: core
     1.3.0 (`fix:` that added an export subpath) and 1.4.0 (`fix:`/`test:` that changed `TaskItem.text` semantics)
     would both have been under-bumped to a patch by a prefix rule
   - **Written at release time, not inside a change.** CHANGELOG entries and version bumps (`package.json` `version`,


### PR DESCRIPTION
Documents a trap created by enabling branch protection: `ci.yml`'s three job names are now pinned as required status checks, so renaming a job leaves PRs **pending forever** on a check that never reports — which reads like CI being down rather than a config error.

That is the third instance of the same shape in this repo, so all three are collected into one table at the top of CLAUDE.md instead of staying scattered:

| Name | Referenced by | Rename does |
|---|---|---|
| `ci.yml` job names | branch protection | PRs pend forever |
| `npm-publish.yml` filename | npm trusted publisher | fails at auth, no cause named |
| `action.yml` build chain | nothing — the absence is the bug | outputs set, files empty |

Also records why `enforce_admins` is deliberately **off**: the `release` skill pushes the `npm version` commit straight to master, and a locally-created commit can never have passed a required check, so enforcing admins would break `/release`.

Verified the three job names match across all three places (`ci.yml`, CLAUDE.md, branch protection).

Docs only — no spec under `openspec/specs/` touched. Also serves as the first live test of the new branch protection.