### PR TITLE
fix(core): pin the parser's line-ending and blank-line boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,19 @@ GET /api/openspec/search?dir=...&q=...              # full-text search
   `CHECKBOX_RE` stays **anchored at column 0**: an indented checkbox belongs to its parent's text and is
   deliberately *not* counted, so relaxing the anchor would move every progress bar and CI badge. First
   lines keep trailing whitespace when folded, or two-space hard breaks silently become soft ones
+- **The parser never lets its runtime decide a boundary** — the rule that was learned twice (issue #33).
+  `parseTasks` and the Kotlin `TaskParser` are one rule written in two languages, and a construct that
+  *reads* the same in both is not the same: Java's regex `$` also matches before a trailing line
+  terminator (and its terminator set covers U+2028 / U+2029 as well as CR), and `isBlank()` /
+  `trim()` disagree over U+00A0, U+FEFF, U+2007, U+202F and U+001C. So both boundaries are now stated,
+  not inherited: **all three CommonMark line endings** (`\n`, `\r\n`, **lone `\r`**) are normalised
+  before the split, and a **blank line is spaces and tabs only** — the same `[ \t]` class the indent
+  rules already use, via `isBlankLine` / `trimSpacesTabs` on both sides. Patterns applied to a
+  split line anchor with `\z` in Kotlin. One divergence is knowingly kept and pinned by a test on both
+  sides: **U+0085** is an ordinary character to JS's `.` and a terminator to Java's, so a line
+  containing it is a task only in TypeScript. Case-mirrored tests **cannot** catch this class — the
+  spelling is the control, not the tests. New cases go in as escape sequences, never literal
+  characters: a raw U+001C or U+0085 gets rewritten on the way into the file and silently guts the test
 - **Webview CSP**: IIFE + nonce script + unsafe-inline styles (Tailwind needs it)
 - **Host flags**: VS Code sets `window.__vscodeApi` (`acquireVsCodeApi` called once, stored globally), IntelliJ
   `window.__spekIntellij`, Demo `window.__DEMO_DATA__`. `useFileWatcher` picks its refresh channel from these flags, so

--- a/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/design.md
+++ b/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/design.md
@@ -1,0 +1,133 @@
+## Context
+
+`parseTasks` (`packages/core/src/tasks.ts`) and `TaskParser.kt`
+(`packages/intellij/src/main/kotlin/com/spek/intellij/core/`) are two implementations of one rule set.
+Nothing links them: they are kept aligned by convention, and verified by unit tests written to mirror
+each other case for case. That mechanism holds for cases someone thought to write down, and
+structurally cannot hold for cases where the *same spelling* means different things to the two
+runtimes.
+
+Both known instances are of that shape. `$` in a regex, and "is this line blank", each delegate a
+boundary decision to the host language instead of stating it. The proposal has the measurements; this
+document is about which way to resolve them and why.
+
+The existing code already knows about this failure mode in one place: `BLOCK_OPENER_RE` writes `\z` on
+the Kotlin side where TypeScript writes `$`, with a comment saying exactly why. That precedent is the
+model here — state the boundary in the pattern rather than inheriting it from the engine.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The two implementations return identical `total`, `completed`, and `sections` for identical input,
+  for every input in the tables in the proposal.
+- Where they currently differ from the reference renderer (`react-markdown` + `remark-gfm`), converge
+  on the reference — the property the folding rules are already specified against — rather than on
+  whichever implementation happens to be the incumbent.
+- Remove the two engine-dependent spellings entirely, so the next reader does not have to know Java and
+  JavaScript regex/whitespace tables to predict behaviour.
+
+**Non-Goals:**
+
+- A differential or shared-fixture test harness. It is the durable answer to this class of drift and it
+  is deliberately deferred (see the proposal); this change adds mirrored cases in the existing style.
+- Full Unicode parity between the two `.` character classes — see Risks for the one residual case that
+  survives, and why closing it is not worth its cost.
+- Any change to the folding rules themselves (dedent width, blank-line boundary, block openers). Only
+  the two boundary *definitions* those rules are built on move.
+
+## Decisions
+
+### D1 — Fix line endings at normalisation, not at the match site
+
+Replace the `\r\n` → `\n` normalisation with one covering all three CommonMark line endings, on both
+sides, keeping the existing "normalise, then split on `\n`" shape:
+
+- TypeScript: `content.replace(/\r\n/g, "\n")` → `content.replace(/\r\n?/g, "\n")`
+- Kotlin: `content.replace("\r\n", "\n")` → `Regex("""\r\n?""").replace(content, "\n")`
+  (Kotlin's two-string `replace` is literal, so this becomes a regex.)
+
+`\r\n?` is greedy on the optional `\n`, so `\r\n` is still consumed as one ending and never becomes two
+line breaks.
+
+*Alternatives considered.* **Kotlin `$` → `\z` alone**, as issue #33 suggests: aligns the two on
+TypeScript's answer, which the reference renderer contradicts, and leaves the multi-line CR-only file
+(row 4 of the proposal's table) broken on both sides. **Strip one trailing `\r` per line after the
+split**: fixes rows 1–3 but not row 4, where the `\r` is interior to the single unsplit line rather
+than trailing — the symptom is addressed, the cause is not. **Split on a line-ending regex** instead of
+normalising first: equivalent in behaviour, but it drops the line-for-line correspondence between the
+two files that keeps them auditable, for no gain.
+
+### D2 — `\z` in Kotlin's `CHECKBOX_RE` and `SECTION_RE` anyway
+
+After D1 no line can contain a `\r`, so for the `\r` case `$` and `\z` are equivalent and this looks
+cosmetic. It is not. Java's `$` matches before a final line terminator, and Java's terminator set is
+larger than CommonMark's — measured on `- [x] a<X>` and `- [x] a<X>b`:
+
+| Trailing char | JS `$` | Java `$` | Java `\z` | Reference |
+|---|---|---|---|---|
+| U+2028 (line separator) | no match | **match** | no match | no match |
+| U+2029 (paragraph separator) | no match | **match** | no match | no match |
+
+`\z` closes U+2028 and U+2029 exactly, and costs nothing. It also makes the two patterns say the same
+thing independently of D1, so a future edit that touches the normalisation cannot silently reopen the
+`\r` divergence.
+
+*Alternative considered.* `RegexOption.UNIX_LINES`, which reduces Java's terminator set to `\n` alone:
+it fixes U+0085 (see Risks) but simultaneously admits U+2028/U+2029 into `.`, where JS excludes them.
+One divergence traded for another, with an extra flag to explain. `\z` strictly dominates.
+
+### D3 — A blank line is spaces and tabs only, spelled explicitly
+
+Replace `line.trim() === ""` (TypeScript) and `line.isBlank()` (Kotlin) with an explicit predicate over
+`[ \t]`. This is CommonMark's definition, it matches the reference renderer, and it is the same
+character class `leadingWhitespace` already uses on both sides — so the file becomes internally
+consistent about what whitespace means.
+
+The same substitution applies everywhere the two implementations lean on the runtime's whitespace
+table, which is four sites each:
+
+1. the blank-line branch in the main loop,
+2. the trailing-blank-line trim in `flush`,
+3. the per-line blank test in `flush`'s continuation map,
+4. `first.trim()` for a single-line task, and the `##` section title trim.
+
+Sites 1–3 are the blank-line predicate. Site 4 is a *trim*, and needs the same treatment for the same
+reason: JS `trim()` strips NBSP and Kotlin's does not, so `- [x] foo<NBSP>` yields different `text` on
+the two sides today, and the reference renders the NBSP.
+
+*Alternatives considered.* **Adopt one runtime's notion** — both are wrong against the reference, in
+opposite directions, so this only picks which files break. **Normalise exotic whitespace out of the
+content**: alters what the user wrote, far beyond a parity fix.
+
+### D4 — Mirrored tests are per-case and explicit
+
+Each table row in the proposal becomes a named test on both sides, with the input built from escape
+sequences rather than literal characters, so the intent survives an editor or a `.gitattributes` pass.
+The existing reference-renderer test (`packages/web/src/components/TaskText.test.ts`) runs over this
+repo's own `tasks.md` files, all of which are LF-normalised and free of exotic whitespace (verified),
+so it cannot exercise any of these cases — the new tests must stand alone rather than lean on it.
+
+## Risks / Trade-offs
+
+**U+0085 (NEL) parity is not achieved, only narrowed** → Accepted and documented in the spec. JS `.`
+matches U+0085 while Java's does not, so `- [x] a<U+0085>b` is a task in TypeScript and not in Kotlin,
+before and after this change (`\z` makes Java reject both forms rather than one). Closing it means
+replacing `(.+)` with an identically-spelled negated class on both sides, which trades a rare
+divergence for permanent extra complexity in the two most load-bearing patterns in the file. U+0085 has
+no natural source in a Markdown task list, unlike `\r` (legacy line endings) and NBSP (copy-paste).
+
+**`total` and `completed` move for some inputs** → Only for files this repo does not contain: verified
+by scanning every `.md` under the repo for CR, NBSP, BOM, U+001C, U+2007, U+202F, NEL, U+2028 and
+U+2029 — zero hits. CLAUDE.md flags moving `total` as high-consequence because it drives progress bars
+and CI badges; here it moves only toward the reference renderer, and only on files that were being
+mis-parsed.
+
+**A published package changes observable output** → `@spekjs/core` consumers can see different
+`total` / `text` for affected files. Recorded in the proposal's Impact for whoever cuts the release,
+with the bump this warrants (minor, not patch).
+
+**The mirrored-test mechanism is still the only guard** → This change fixes two instances and leaves
+the mechanism that let them through intact. The follow-up fixture corpus is the real fix; until then a
+third instance of the same class is a live possibility. Both instances fixed here were found by
+manually comparing engine semantics, which does not scale.

--- a/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/proposal.md
+++ b/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/proposal.md
@@ -1,0 +1,96 @@
+## Why
+
+The task parser exists twice — `parseTasks` in `@spekjs/core` and its Kotlin mirror `TaskParser.kt` —
+and each carries a rule spelled the same way on both sides that the two language runtimes read
+differently. Two such rules are known, and neither is caught by the case-mirrored unit tests that are
+currently the only thing holding the implementations together.
+
+### Line endings (issue #33)
+
+The two disagree about whether a line ending in a bare `\r` holds a checkbox. Both use the pattern
+`^- \[([ xX])] (.+)$`, but Java's `$` also matches before a final line terminator while JavaScript's
+`$` (no `m` flag) matches only at the absolute end of the string. The same `tasks.md` therefore yields
+a different `total` in the IntelliJ plugin than in the Web and VS Code surfaces.
+
+Measuring both against the reference renderer (`react-markdown` + `remark-gfm`, the same reference the
+existing folding tests compare to) shows the divergence is not the whole problem — the TypeScript side
+is the one that is wrong:
+
+| Source | Reference | Kotlin | TypeScript |
+|---|---|---|---|
+| `- [x] a\r` | 1 | 1 | **0** |
+| `- [x] a\r\r\n- [x] b` | 2 | 2 | **1** |
+| `- [x] a\n- [x] b\r` | 2 | 2 | **1** |
+| `- [x] a\r- [x] b` | 2 | **0** | **0** |
+
+CommonMark defines a line ending as `\n`, `\r\n`, **or a lone `\r`**, and the reference renderer honours
+all three. Both implementations normalise only `\r\n` before splitting on `\n`, so a lone `\r` is never
+a line break to either of them — which is why the last row is wrong on both sides and absent from the
+issue's own analysis. Aligning Kotlin down to TypeScript's answer, as the issue suggests, would settle
+the two on the wrong result and leave that row broken.
+
+### Blank lines
+
+Found while verifying the above, and the same defect in a different rule. A blank line is spelled
+`line.trim() === ""` in TypeScript and `line.isBlank()` in Kotlin — one intent, two different notions
+of whitespace. CommonMark's is a third: a blank line contains only spaces and tabs.
+
+| Line content | Reference | Kotlin | TypeScript |
+|---|---|---|---|
+| U+00A0 (NBSP) | not blank | not blank | **blank** |
+| U+FEFF (BOM), U+2007, U+202F | not blank | not blank | **blank** |
+| U+001C (file separator) | not blank | **blank** | not blank |
+
+Each implementation is wrong in one direction. It matters because a blank line moves the continuation
+boundary: with `- [ ] Task`, an NBSP-only line, then unindented prose, the reference keeps the prose
+inside the task while TypeScript drops it. NBSP survives ordinary copy-paste, so this is reachable
+without any of the exotic file encodings the `\r` case needs.
+
+## What Changes
+
+- Normalise all three CommonMark line endings — `\r\n`, `\r`, `\n` — to `\n` before splitting, in both
+  `packages/core/src/tasks.ts` and `packages/intellij/.../core/TaskParser.kt`. This aligns the two
+  implementations *and* aligns both with the reference renderer.
+- Replace `$` with `\z` in the Kotlin `CHECKBOX_RE` and `SECTION_RE`. Once no line carries a trailing
+  `\r` the two spellings are equivalent, so this changes no behaviour; it removes the engine-dependent
+  reading and matches what `BLOCK_OPENER_RE` already does deliberately for the same reason.
+- Define a blank line explicitly as "spaces and tabs only" on both sides, replacing `trim() === ""` and
+  `isBlank()`. This is CommonMark's rule and the same `[ \t]` class `leadingWhitespace` already uses on
+  both sides, so the two implementations stop depending on their runtime's whitespace table.
+- Add mirrored tests on both sides covering each row of the tables above — case-mirrored unit tests are
+  currently the only mechanism keeping the two parsers honest.
+
+Deliberately out of scope: the shared-fixture / differential-test corpus that would catch this class of
+drift structurally rather than by remembering to mirror each case. It is a larger piece of work with
+its own design questions (where the fixtures live, how the Gradle and Node suites both consume them);
+this change fixes the defect and leaves that as a follow-up.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `task-parser`: add requirements fixing the two boundary definitions the parser leaves to its runtime
+  today — which byte sequences end a line, and which characters make a line blank — and stating that
+  both hold identically across implementations, so every surface reports the same tasks for the same
+  file.
+
+## Impact
+
+- `packages/core/src/tasks.ts` — line-ending normalisation and the blank-line predicate in `parseTasks`.
+- `packages/intellij/src/main/kotlin/com/spek/intellij/core/TaskParser.kt` — the same two, plus `\z` in
+  `CHECKBOX_RE` / `SECTION_RE`.
+- `packages/core/src/tasks.test.ts` and
+  `packages/intellij/src/test/kotlin/com/spek/intellij/core/TaskParserTest.kt` — mirrored cases.
+- **Behaviour change for `@spekjs/core` consumers**, on files this repo does not contain:
+  - `total` / `completed` / `sections` change for a `tasks.md` using lone `\r` line endings —
+    previously under-counted, now counted.
+  - A task's `text` changes where an exotic-whitespace-only line sits inside or after it.
+
+  Nothing in this repo moves (it is LF-normalised via `.gitattributes` and carries no such whitespace),
+  and the badge generator and progress bars read whatever the parser returns, so they follow
+  automatically. **For whoever cuts the release**: these are observable output changes in a published
+  package, so they warrant a **minor** bump of `@spekjs/core`, not a patch.

--- a/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/specs/task-parser/spec.md
+++ b/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/specs/task-parser/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Line endings follow CommonMark
+
+The task parser SHALL recognise all three CommonMark line endings — a line feed, a carriage return
+followed by a line feed, and a **lone carriage return** — as a single line ending each, and SHALL
+normalise every one of them to a line feed before splitting the content into lines. No line handed to
+the checkbox, section, or continuation rules SHALL contain a carriage return.
+
+The parser SHALL NOT delegate this decision to its host runtime's notion of a line terminator. Java's
+regex `$` matches before a trailing line terminator and JavaScript's does not, so a pattern anchored
+with `$` reads differently in the two implementations; patterns applied to an already-split line SHALL
+therefore be anchored at the absolute end of the string (`\z` in the Kotlin implementation, `$` in the
+TypeScript one, which already means that).
+
+#### Scenario: Carriage-return-only file
+
+- **WHEN** parser receives `- [x] a`, a lone carriage return, then `- [ ] b`, with no line feed anywhere
+- **THEN** `total` is 2 and `completed` is 1, matching what a standard CommonMark+GFM renderer shows
+
+#### Scenario: Stray carriage return before a CRLF
+
+- **WHEN** parser receives a checkbox line terminated by carriage return, carriage return, line feed,
+  followed by a second checkbox line
+- **THEN** both checkboxes are counted, and the doubled ending is treated as an ordinary blank line
+  between them rather than leaving a carriage return inside the first line
+
+#### Scenario: Final line terminated by a carriage return
+
+- **WHEN** parser receives line-feed-separated checkboxes whose last line ends with a lone carriage
+  return
+- **THEN** the last checkbox is counted, and its `text` does not contain the carriage return
+
+#### Scenario: Ordinary CRLF content is unaffected
+
+- **WHEN** parser receives a CRLF-terminated tasks.md
+- **THEN** the result is identical to the same content with line-feed endings
+
+### Requirement: Blank lines are spaces and tabs only
+
+The task parser SHALL treat a line as blank when it is empty or contains only spaces (U+0020) and tabs
+(U+0009), and SHALL NOT treat any other whitespace character as making a line blank. This is
+CommonMark's definition and the same character class the parser already uses to measure a line's
+leading whitespace.
+
+The definition SHALL be spelled explicitly rather than inherited from the host runtime, whose
+whitespace tables disagree with CommonMark and with each other — JavaScript's `String.prototype.trim`
+strips U+00A0, U+FEFF, U+2007 and U+202F while Kotlin's `isBlank` does not, and Kotlin's `isBlank`
+treats U+001C as whitespace while JavaScript's `trim` does not.
+
+This definition governs every place blankness or trimming decides an outcome: the blank-line boundary
+for continuation lines, the dropping of trailing blank lines from a task's text, the blanking of
+interior lines when continuation lines are folded, and the trimming of a single-line task's text and of
+a `##` section title.
+
+#### Scenario: A no-break-space line does not end a task
+
+- **WHEN** parser receives `- [ ] Task`, a line containing only U+00A0, then unindented prose
+- **THEN** all three lines are part of that task's `text`, because the middle line is not blank and the
+  prose is therefore lazy continuation rather than a new paragraph
+
+#### Scenario: A file-separator line does not end a task
+
+- **WHEN** parser receives `- [ ] Task`, a line containing only U+001C, then unindented prose
+- **THEN** all three lines are part of that task's `text`
+
+#### Scenario: A spaces-and-tabs line is blank
+
+- **WHEN** parser receives `- [ ] Task`, a line of two spaces and a tab, then unindented prose
+- **THEN** the prose is not part of the task's `text`, the same as for an empty line
+
+#### Scenario: Exotic trailing whitespace survives trimming
+
+- **WHEN** parser receives a single-line checkbox whose text ends with U+00A0
+- **THEN** that character is retained in the task's `text`, while ordinary trailing spaces and tabs are
+  still removed
+
+### Requirement: Implementations agree on every input
+
+Every implementation of the task parser SHALL return the same `total`, `completed`, and section/task
+structure for the same input, so that every delivery surface reports the same tasks for the same file.
+There are two: `parseTasks` in `@spekjs/core`, and the Kotlin `TaskParser` used by the IntelliJ plugin.
+
+Where a rule could otherwise be inherited from the host runtime — a regex anchor's notion of a line
+terminator, a whitespace predicate's notion of blank — the rule SHALL be stated explicitly in the
+pattern or predicate, in a form that reads identically in both languages. Case-mirrored unit tests
+cannot detect a rule that both implementations spell the same way and each runtime reads differently,
+so the spelling is the control, not the tests.
+
+One divergence is knowingly retained: U+0085 (next line) is an ordinary character to JavaScript's `.`
+and a line terminator to Java's, so a checkbox line containing it is a task to the TypeScript
+implementation and not to the Kotlin one. Closing it requires replacing `(.+)` with an identically
+spelled negated character class in both engines, which is not worth the permanent cost in the parser's
+two most load-bearing patterns for a character with no natural source in a task list.
+
+#### Scenario: Same input, same output
+
+- **WHEN** the same tasks.md content is parsed by `@spekjs/core` and by the Kotlin implementation
+- **THEN** both return the same `total`, the same `completed`, and the same sections with the same task
+  texts, for every input covered by this capability's scenarios
+
+#### Scenario: Next-line character is a documented exception
+
+- **WHEN** a checkbox line contains U+0085 followed by further text
+- **THEN** `@spekjs/core` counts it as one task whose text includes the character, the Kotlin
+  implementation counts no task, and this difference is accepted rather than treated as a defect

--- a/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/tasks.md
+++ b/openspec/changes/archive/2026-08-06-fix-task-parser-runtime-parity/tasks.md
@@ -1,0 +1,47 @@
+## 1. TypeScript parser (`packages/core/src/tasks.ts`)
+
+- [x] 1.1 Widen the line-ending normalisation in `parseTasks` from `/\r\n/g` to `/\r\n?/g`, so a lone
+      carriage return also becomes a line feed before the split
+- [x] 1.2 Add an explicit `isBlankLine(line)` helper matching only spaces and tabs, and use it at the
+      three blankness sites: the blank-line branch in the main loop, the trailing-blank-line trim in
+      `flush`, and the per-line blank test in `flush`'s continuation map
+- [x] 1.3 Add an explicit spaces-and-tabs trim helper and use it for a single-line task's `text` and for
+      the `##` section title, replacing `String.prototype.trim`
+- [x] 1.4 Comment both rules in the style of the surrounding ones — what the runtime would otherwise
+      decide, and why CommonMark's answer is the one being pinned
+
+## 2. Kotlin parser (`packages/intellij/src/main/kotlin/com/spek/intellij/core/TaskParser.kt`)
+
+- [x] 2.1 Widen the line-ending normalisation to `Regex("""\r\n?""")` (the two-string `replace` is
+      literal, so this becomes a regex)
+- [x] 2.2 Replace `$` with `\z` in `CHECKBOX_RE` and `SECTION_RE`, matching what `BLOCK_OPENER_RE`
+      already does, and note that Java's `$` also admits U+2028 / U+2029
+- [x] 2.3 Mirror 1.2 and 1.3: a spaces-and-tabs `isBlankLine` replacing `isBlank()` at the three sites,
+      and a spaces-and-tabs trim replacing `trim()` for task text and section title
+- [x] 2.4 Mirror the comments from 1.4, keeping the two files line-for-line comparable
+
+## 3. Tests
+
+- [x] 3.1 `packages/core/src/tasks.test.ts`: line-ending cases — CR-only file, `\r\r\n`, final line
+      ending in CR, and a CRLF regression guard. Build inputs from escape sequences so the intent
+      survives an editor or `.gitattributes` pass
+- [x] 3.2 `packages/core/src/tasks.test.ts`: blank-line cases — U+00A0-only and U+001C-only lines do not
+      end a task, a spaces-and-tabs line does, and trailing U+00A0 survives trimming
+- [x] 3.3 `packages/intellij/src/test/kotlin/com/spek/intellij/core/TaskParserTest.kt`: mirror every
+      case from 3.1 and 3.2, same names, same expectations
+- [x] 3.4 Pin the accepted U+0085 divergence on both sides — the TypeScript test asserts it counts, the
+      Kotlin test asserts it does not — so the exception stays visible and an accidental change to
+      either side fails
+
+## 4. Documentation
+
+- [x] 4.1 Extend the `tasks.md` parsing bullet in `CLAUDE.md` with the two boundary rules now fixed
+      (all three CommonMark line endings; blank means spaces and tabs only) and the U+0085 exception,
+      since that bullet is where the parser's non-obvious semantics are recorded
+
+## 5. Gates
+
+- [x] 5.1 `npm run build:core` and `npm run build -w @spekjs/ui` before running the Node gates — the web
+      package imports core's `dist`, so tests against an unbuilt core exercise the previous build
+- [x] 5.2 `npm run type-check`, `npm run lint`, `npm test`
+- [x] 5.3 `./gradlew test` in `packages/intellij`

--- a/openspec/specs/task-parser/spec.md
+++ b/openspec/specs/task-parser/spec.md
@@ -133,3 +133,108 @@ downgraded to a soft break.
 #### Scenario: Soft line break stays soft
 - **WHEN** parser receives a checkbox line with no trailing whitespace followed by a continuation line
 - **THEN** the two lines render as a single wrapped line, not as a hard break
+
+### Requirement: Line endings follow CommonMark
+
+The task parser SHALL recognise all three CommonMark line endings — a line feed, a carriage return
+followed by a line feed, and a **lone carriage return** — as a single line ending each, and SHALL
+normalise every one of them to a line feed before splitting the content into lines. No line handed to
+the checkbox, section, or continuation rules SHALL contain a carriage return.
+
+The parser SHALL NOT delegate this decision to its host runtime's notion of a line terminator. Java's
+regex `$` matches before a trailing line terminator and JavaScript's does not, so a pattern anchored
+with `$` reads differently in the two implementations; patterns applied to an already-split line SHALL
+therefore be anchored at the absolute end of the string (`\z` in the Kotlin implementation, `$` in the
+TypeScript one, which already means that).
+
+#### Scenario: Carriage-return-only file
+
+- **WHEN** parser receives `- [x] a`, a lone carriage return, then `- [ ] b`, with no line feed anywhere
+- **THEN** `total` is 2 and `completed` is 1, matching what a standard CommonMark+GFM renderer shows
+
+#### Scenario: Stray carriage return before a CRLF
+
+- **WHEN** parser receives a checkbox line terminated by carriage return, carriage return, line feed,
+  followed by a second checkbox line
+- **THEN** both checkboxes are counted, and the doubled ending is treated as an ordinary blank line
+  between them rather than leaving a carriage return inside the first line
+
+#### Scenario: Final line terminated by a carriage return
+
+- **WHEN** parser receives line-feed-separated checkboxes whose last line ends with a lone carriage
+  return
+- **THEN** the last checkbox is counted, and its `text` does not contain the carriage return
+
+#### Scenario: Ordinary CRLF content is unaffected
+
+- **WHEN** parser receives a CRLF-terminated tasks.md
+- **THEN** the result is identical to the same content with line-feed endings
+
+### Requirement: Blank lines are spaces and tabs only
+
+The task parser SHALL treat a line as blank when it is empty or contains only spaces (U+0020) and tabs
+(U+0009), and SHALL NOT treat any other whitespace character as making a line blank. This is
+CommonMark's definition and the same character class the parser already uses to measure a line's
+leading whitespace.
+
+The definition SHALL be spelled explicitly rather than inherited from the host runtime, whose
+whitespace tables disagree with CommonMark and with each other — JavaScript's `String.prototype.trim`
+strips U+00A0, U+FEFF, U+2007 and U+202F while Kotlin's `isBlank` does not, and Kotlin's `isBlank`
+treats U+001C as whitespace while JavaScript's `trim` does not.
+
+This definition governs every place blankness or trimming decides an outcome: the blank-line boundary
+for continuation lines, the dropping of trailing blank lines from a task's text, the blanking of
+interior lines when continuation lines are folded, and the trimming of a single-line task's text and of
+a `##` section title.
+
+#### Scenario: A no-break-space line does not end a task
+
+- **WHEN** parser receives `- [ ] Task`, a line containing only U+00A0, then unindented prose
+- **THEN** all three lines are part of that task's `text`, because the middle line is not blank and the
+  prose is therefore lazy continuation rather than a new paragraph
+
+#### Scenario: A file-separator line does not end a task
+
+- **WHEN** parser receives `- [ ] Task`, a line containing only U+001C, then unindented prose
+- **THEN** all three lines are part of that task's `text`
+
+#### Scenario: A spaces-and-tabs line is blank
+
+- **WHEN** parser receives `- [ ] Task`, a line of two spaces and a tab, then unindented prose
+- **THEN** the prose is not part of the task's `text`, the same as for an empty line
+
+#### Scenario: Exotic trailing whitespace survives trimming
+
+- **WHEN** parser receives a single-line checkbox whose text ends with U+00A0
+- **THEN** that character is retained in the task's `text`, while ordinary trailing spaces and tabs are
+  still removed
+
+### Requirement: Implementations agree on every input
+
+Every implementation of the task parser SHALL return the same `total`, `completed`, and section/task
+structure for the same input, so that every delivery surface reports the same tasks for the same file.
+There are two: `parseTasks` in `@spekjs/core`, and the Kotlin `TaskParser` used by the IntelliJ plugin.
+
+Where a rule could otherwise be inherited from the host runtime — a regex anchor's notion of a line
+terminator, a whitespace predicate's notion of blank — the rule SHALL be stated explicitly in the
+pattern or predicate, in a form that reads identically in both languages. Case-mirrored unit tests
+cannot detect a rule that both implementations spell the same way and each runtime reads differently,
+so the spelling is the control, not the tests.
+
+One divergence is knowingly retained: U+0085 (next line) is an ordinary character to JavaScript's `.`
+and a line terminator to Java's, so a checkbox line containing it is a task to the TypeScript
+implementation and not to the Kotlin one. Closing it requires replacing `(.+)` with an identically
+spelled negated character class in both engines, which is not worth the permanent cost in the parser's
+two most load-bearing patterns for a character with no natural source in a task list.
+
+#### Scenario: Same input, same output
+
+- **WHEN** the same tasks.md content is parsed by `@spekjs/core` and by the Kotlin implementation
+- **THEN** both return the same `total`, the same `completed`, and the same sections with the same task
+  texts, for every input covered by this capability's scenarios
+
+#### Scenario: Next-line character is a documented exception
+
+- **WHEN** a checkbox line contains U+0085 followed by further text
+- **THEN** `@spekjs/core` counts it as one task whose text includes the character, the Kotlin
+  implementation counts no task, and this difference is accepted rather than treated as a defect

--- a/packages/core/src/tasks.test.ts
+++ b/packages/core/src/tasks.test.ts
@@ -177,3 +177,71 @@ test("parseTasks: a block opener between tasks leaves the counts alone", () => {
     ["one", "two"]
   );
 });
+
+// Line endings and blankness are the two boundaries this parser used to inherit from its runtime,
+// where JavaScript and Kotlin disagree with each other and with CommonMark. Every case below is
+// written with escape sequences rather than literal characters, so neither an editor nor a
+// `.gitattributes` pass can quietly rewrite the thing under test. TaskParserTest.kt mirrors them.
+
+test("parseTasks: a carriage-return-only file separates its lines", () => {
+  // CommonMark counts a lone CR as a line ending, so this is two tasks, not one unparseable line.
+  const parsed = parseTasks("- [x] a\r- [ ] b");
+  assert.equal(parsed.total, 2);
+  assert.equal(parsed.completed, 1);
+});
+
+test("parseTasks: a stray carriage return before a CRLF does not survive into the line", () => {
+  // `\r\r\n` normalises to two line endings; the leftover CR used to make Java see a checkbox where
+  // JavaScript saw none.
+  assert.deepEqual(textOf("- [x] a\r\r\n- [x] b"), ["a", "b"]);
+});
+
+test("parseTasks: a final line ending in a carriage return is still a task", () => {
+  assert.deepEqual(textOf("- [x] a\n- [ ] b\r"), ["a", "b"]);
+});
+
+test("parseTasks: CRLF content parses the same as LF", () => {
+  assert.deepEqual(
+    parseTasks("## S\r\n- [x] a\r\n- [ ] b\r\n"),
+    parseTasks("## S\n- [x] a\n- [ ] b\n")
+  );
+});
+
+test("parseTasks: a no-break-space line does not end the task", () => {
+  // A blank line is spaces and tabs only, so this line is content and the prose after it is lazy
+  // continuation — which is what the reference renderer shows. `trim() === ""` called it blank and
+  // dropped the prose; Kotlin's `isBlank()` never did.
+  assert.deepEqual(textOf("- [ ] Task\n\u00a0\nprose"), ["Task\n\u00a0\nprose"]);
+});
+
+test("parseTasks: a file-separator line does not end the task", () => {
+  // The mirror image: Kotlin's `isBlank()` counts U+001C as whitespace, JavaScript's `trim()` does
+  // not, and CommonMark agrees with neither runtime's table — only spaces and tabs are blank.
+  assert.deepEqual(textOf("- [ ] Task\n\u001c\nprose"), ["Task\n\u001c\nprose"]);
+});
+
+test("parseTasks: a spaces-and-tabs line is blank", () => {
+  assert.deepEqual(textOf("- [ ] Task\n \t \nprose"), ["Task"]);
+});
+
+test("parseTasks: exotic trailing whitespace survives trimming", () => {
+  assert.deepEqual(textOf("- [x] Task\u00a0  "), ["Task\u00a0"]);
+});
+
+test("parseTasks: a section title is trimmed to the same class", () => {
+  // The title goes through the same spaces-and-tabs trim as a single-line task's text, so a trailing
+  // NBSP stays and ordinary trailing spaces go.
+  const parsed = parseTasks("## Phase\u00a0  \n- [x] a\n");
+  assert.deepEqual(
+    parsed.sections.map((s) => s.title),
+    ["Phase\u00a0"]
+  );
+});
+
+test("parseTasks: a next-line character stays in the text (known divergence)", () => {
+  // U+0085 is an ordinary character to JavaScript's `.` and a line terminator to Java's, so the
+  // Kotlin mirror counts no task here at all. Accepted rather than fixed — closing it means spelling
+  // an identical negated class into both engines' `(.+)` — and pinned on both sides so it stays a
+  // documented exception instead of drifting. See the task-parser spec.
+  assert.deepEqual(textOf("- [x] a\u0085b"), ["a\u0085b"]);
+});

--- a/packages/core/src/tasks.ts
+++ b/packages/core/src/tasks.ts
@@ -26,6 +26,14 @@ export interface ParsedTasks extends TaskStats {
 const CHECKBOX_RE = /^- \[([ xX])\] (.+)$/;
 const SECTION_RE = /^## (.+)$/;
 
+// Every CommonMark line ending: LF, CRLF, and a *lone* CR. Normalising only CRLF left a lone CR
+// sitting inside a line, and from there the two implementations of this parser disagreed about
+// whether such a line held a checkbox at all — Java's `$` matches before a trailing line terminator,
+// JavaScript's does not (issue #33). Both answers were wrong: the reference renderer treats the CR as
+// a line ending and sees a task on each side of it. Normalising all three here means no rule below
+// ever meets a CR, so neither engine's line-terminator table can influence the result.
+const LINE_ENDING_RE = /\r\n?/g;
+
 // Width of the `- ` list marker, i.e. CommonMark's content offset for these items. Continuation
 // lines are dedented by this much so the folded text renders the way a standard renderer shows the
 // original source — no more. Stripping the full indent instead would promote deeply indented lines
@@ -40,6 +48,30 @@ function dedentContinuation(line: string): string {
 
 function leadingWhitespace(line: string): number {
   return /^[ \t]*/.exec(line)![0].length;
+}
+
+// CommonMark's blank line — spaces and tabs only — spelled out rather than delegated to the runtime.
+// `trim() === ""` and Kotlin's `isBlank()` are each a different set: JavaScript strips U+00A0, U+FEFF,
+// U+2007 and U+202F, Kotlin counts U+001C, and CommonMark counts none of them. Since blankness moves
+// the continuation boundary, the two implementations folded different text for the same file. This is
+// the same `[ \t]` class `leadingWhitespace` measures, kept as an explicit loop so the Kotlin mirror
+// can say it identically.
+function isBlankLine(line: string): boolean {
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch !== " " && ch !== "\t") return false;
+  }
+  return true;
+}
+
+// Trim to the same class, for the same reason: `String.prototype.trim` would eat a trailing U+00A0
+// that the reference renderer displays, and Kotlin's `trim()` would leave it.
+function trimSpacesTabs(text: string): string {
+  let start = 0;
+  let end = text.length;
+  while (start < end && (text[start] === " " || text[start] === "\t")) start++;
+  while (end > start && (text[end - 1] === " " || text[end - 1] === "\t")) end--;
+  return text.slice(start, end);
 }
 
 // A column-0 line that opens a new block, which ends the preceding item rather than continuing it.
@@ -94,7 +126,7 @@ interface PendingTask {
 }
 
 export function parseTasks(content: string): ParsedTasks {
-  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  const lines = content.replace(LINE_ENDING_RE, "\n").split("\n");
   const sections: TaskSection[] = [];
   let currentSection: TaskSection = { title: "", tasks: [] };
   let total = 0;
@@ -109,13 +141,13 @@ export function parseTasks(content: string): ParsedTasks {
   function flush(): void {
     if (!pending) return;
     const { first, rest } = pending;
-    while (rest.length > 0 && rest[rest.length - 1].trim() === "") rest.pop();
+    while (rest.length > 0 && isBlankLine(rest[rest.length - 1])) rest.pop();
     // With continuation lines the first line is kept verbatim: two trailing spaces are a hard line
     // break, and trimming them would quietly downgrade it to a soft one.
     const text =
       rest.length > 0
-        ? [first, ...rest.map((l) => (l.trim() === "" ? "" : dedentContinuation(l)))].join("\n")
-        : first.trim();
+        ? [first, ...rest.map((l) => (isBlankLine(l) ? "" : dedentContinuation(l)))].join("\n")
+        : trimSpacesTabs(first);
     currentSection.tasks.push({ text, completed: pending.completed });
     total++;
     if (pending.completed) completed++;
@@ -129,7 +161,7 @@ export function parseTasks(content: string): ParsedTasks {
       if (currentSection.tasks.length > 0) {
         sections.push(currentSection);
       }
-      currentSection = { title: sectionMatch[1].trim(), tasks: [] };
+      currentSection = { title: trimSpacesTabs(sectionMatch[1]), tasks: [] };
       sawBlank = false;
       continue;
     }
@@ -148,7 +180,7 @@ export function parseTasks(content: string): ParsedTasks {
 
     if (!pending) continue;
 
-    if (line.trim() === "") {
+    if (isBlankLine(line)) {
       sawBlank = true;
       pending.rest.push(line);
       continue;

--- a/packages/intellij/src/main/kotlin/com/spek/intellij/core/TaskParser.kt
+++ b/packages/intellij/src/main/kotlin/com/spek/intellij/core/TaskParser.kt
@@ -7,8 +7,20 @@ package com.spek.intellij.core
 object TaskParser {
     // Anchored at column 0 on purpose: an indented checkbox is part of its parent task's text, not a
     // task of its own. Relaxing this would silently change every total / completed and CI badge.
-    private val CHECKBOX_RE = Regex("""^- \[([ xX])] (.+)$""")
-    private val SECTION_RE = Regex("""^## (.+)$""")
+    //
+    // `\z`, not `$`, for the same reason BLOCK_OPENER_RE below uses it: on an already-split line JS's
+    // `$` means the absolute end of the string, while Java's also matches before a trailing line
+    // terminator — and Java's terminator set is wider than CommonMark's, covering U+2028 and U+2029
+    // as well as CR. The normalisation in parse() removes CR, so `\z` is what closes the rest.
+    private val CHECKBOX_RE = Regex("""^- \[([ xX])] (.+)\z""")
+    private val SECTION_RE = Regex("""^## (.+)\z""")
+
+    // Every CommonMark line ending: LF, CRLF, and a *lone* CR. Normalising only CRLF left a lone CR
+    // sitting inside a line, and from there this parser and the TypeScript one disagreed about
+    // whether such a line held a checkbox at all (issue #33) — both wrong, since the reference
+    // renderer treats the CR as a line ending and sees a task on each side of it. String.replace with
+    // two strings is literal in Kotlin, so this is a regex.
+    private val LINE_ENDING_RE = Regex("""\r\n?""")
 
     // Width of the "- " list marker, i.e. CommonMark's content offset for these items. Continuation
     // lines are dedented by this much so the folded text renders the way a standard renderer shows
@@ -25,6 +37,26 @@ object TaskParser {
         var n = 0
         while (n < line.length && (line[n] == ' ' || line[n] == '\t')) n++
         return n
+    }
+
+    // CommonMark's blank line — spaces and tabs only — spelled out rather than delegated to the
+    // runtime. `isBlank()` and JS's `trim() === ""` are each a different set: Kotlin counts U+001C,
+    // JavaScript strips U+00A0, U+FEFF, U+2007 and U+202F, and CommonMark counts none of them. Since
+    // blankness moves the continuation boundary, the two implementations folded different text for the
+    // same file. Same `[ \t]` class leadingWhitespace measures, written the same way as its TS twin.
+    private fun isBlankLine(line: String): Boolean {
+        for (ch in line) if (ch != ' ' && ch != '\t') return false
+        return true
+    }
+
+    // Trim to the same class, for the same reason: Kotlin's trim() would leave a trailing U+00A0 that
+    // JS's would eat, and the reference renderer displays it.
+    private fun trimSpacesTabs(text: String): String {
+        var start = 0
+        var end = text.length
+        while (start < end && (text[start] == ' ' || text[start] == '\t')) start++
+        while (end > start && (text[end - 1] == ' ' || text[end - 1] == '\t')) end--
+        return text.substring(start, end)
     }
 
     // A column-0 line that opens a new block, which ends the preceding item rather than continuing
@@ -58,7 +90,7 @@ object TaskParser {
     }
 
     fun parse(content: String): ParsedTasks {
-        val lines = content.replace("\r\n", "\n").split("\n")
+        val lines = LINE_ENDING_RE.replace(content, "\n").split("\n")
         val sections = mutableListOf<TaskSection>()
         var currentTitle = ""
         var currentTasks = mutableListOf<TaskItem>()
@@ -73,14 +105,14 @@ object TaskParser {
         fun flush() {
             val task = pending ?: return
             val rest = task.rest
-            while (rest.isNotEmpty() && rest[rest.size - 1].isBlank()) rest.removeAt(rest.size - 1)
+            while (rest.isNotEmpty() && isBlankLine(rest[rest.size - 1])) rest.removeAt(rest.size - 1)
             // With continuation lines the first line is kept verbatim: two trailing spaces are a hard
             // line break, and trimming them would quietly downgrade it to a soft one.
             val text = if (rest.isNotEmpty()) {
-                (listOf(task.first) + rest.map { if (it.isBlank()) "" else dedentContinuation(it) })
+                (listOf(task.first) + rest.map { if (isBlankLine(it)) "" else dedentContinuation(it) })
                     .joinToString("\n")
             } else {
-                task.first.trim()
+                trimSpacesTabs(task.first)
             }
             currentTasks.add(TaskItem(text, task.completed))
             total++
@@ -95,7 +127,7 @@ object TaskParser {
                 if (currentTasks.isNotEmpty()) {
                     sections.add(TaskSection(currentTitle, currentTasks.toList()))
                 }
-                currentTitle = sectionMatch.groupValues[1].trim()
+                currentTitle = trimSpacesTabs(sectionMatch.groupValues[1])
                 currentTasks = mutableListOf()
                 sawBlank = false
                 continue
@@ -114,7 +146,7 @@ object TaskParser {
 
             val task = pending ?: continue
 
-            if (line.isBlank()) {
+            if (isBlankLine(line)) {
                 sawBlank = true
                 task.rest.add(line)
                 continue

--- a/packages/intellij/src/test/kotlin/com/spek/intellij/core/TaskParserTest.kt
+++ b/packages/intellij/src/test/kotlin/com/spek/intellij/core/TaskParserTest.kt
@@ -210,4 +210,78 @@ class TaskParserTest {
         assertEquals(1, parsed.completed)
         assertEquals(listOf("one", "two"), parsed.sections[0].tasks.map { it.text })
     }
+
+    // Line endings and blankness are the two boundaries this parser used to inherit from its runtime,
+    // where Kotlin and JavaScript disagree with each other and with CommonMark. Every case below is
+    // written with escape sequences rather than literal characters, so neither an editor nor a
+    // `.gitattributes` pass can quietly rewrite the thing under test. tasks.test.ts mirrors them.
+
+    @Test
+    fun `a carriage-return-only file separates its lines`() {
+        // CommonMark counts a lone CR as a line ending, so this is two tasks, not one unparseable line.
+        val parsed = TaskParser.parse("- [x] a\r- [ ] b")
+        assertEquals(2, parsed.total)
+        assertEquals(1, parsed.completed)
+    }
+
+    @Test
+    fun `a stray carriage return before a CRLF does not survive into the line`() {
+        // The leftover CR used to make this parser see a checkbox where @spekjs/core saw none.
+        assertEquals(listOf("a", "b"), textOf("- [x] a\r\r\n- [x] b"))
+    }
+
+    @Test
+    fun `a final line ending in a carriage return is still a task`() {
+        assertEquals(listOf("a", "b"), textOf("- [x] a\n- [ ] b\r"))
+    }
+
+    @Test
+    fun `CRLF content parses the same as LF`() {
+        assertEquals(
+            TaskParser.parse("## S\n- [x] a\n- [ ] b\n"),
+            TaskParser.parse("## S\r\n- [x] a\r\n- [ ] b\r\n"),
+        )
+    }
+
+    @Test
+    fun `a no-break-space line does not end the task`() {
+        // A blank line is spaces and tabs only, so this line is content and the prose after it is
+        // lazy continuation — which is what the reference renderer shows. JS's `trim() === ""` called
+        // it blank and dropped the prose; `isBlank()` never did.
+        assertEquals(listOf("Task\n\u00a0\nprose"), textOf("- [ ] Task\n\u00a0\nprose"))
+    }
+
+    @Test
+    fun `a file-separator line does not end the task`() {
+        // The mirror image: `isBlank()` counts U+001C as whitespace, JS's `trim()` does not, and
+        // CommonMark agrees with neither runtime's table — only spaces and tabs are blank.
+        assertEquals(listOf("Task\n\u001c\nprose"), textOf("- [ ] Task\n\u001c\nprose"))
+    }
+
+    @Test
+    fun `a spaces-and-tabs line is blank`() {
+        assertEquals(listOf("Task"), textOf("- [ ] Task\n \t \nprose"))
+    }
+
+    @Test
+    fun `exotic trailing whitespace survives trimming`() {
+        assertEquals(listOf("Task\u00a0"), textOf("- [x] Task\u00a0  "))
+    }
+
+    @Test
+    fun `a section title is trimmed to the same class`() {
+        // The title goes through the same spaces-and-tabs trim as a single-line task's text, so a
+        // trailing NBSP stays and ordinary trailing spaces go.
+        val parsed = TaskParser.parse("## Phase\u00a0  \n- [x] a\n")
+        assertEquals(listOf("Phase\u00a0"), parsed.sections.map { it.title })
+    }
+
+    @Test
+    fun `a next-line character is not a task here (known divergence)`() {
+        // U+0085 is a line terminator to Java's `.` and an ordinary character to JavaScript's, so
+        // @spekjs/core counts one task here and this parser counts none. Accepted rather than fixed —
+        // closing it means spelling an identical negated class into both engines' `(.+)` — and pinned
+        // on both sides so it stays a documented exception instead of drifting. See the task-parser spec.
+        assertEquals(0, TaskParser.parse("- [x] a\u0085b").total)
+    }
 }


### PR DESCRIPTION
Closes #33.

## The problem

`parseTasks` and the Kotlin `TaskParser` are one rule written in two languages, and each left two
boundary decisions to its runtime — where the two runtimes disagree, and case-mirrored unit tests
cannot notice, because both sides spell the rule the same way.

**Line endings.** Java's regex `$` also matches before a trailing line terminator; JavaScript's does
not. A `tasks.md` leaving a bare `\r` at the end of a line therefore reported a different `total` in
IntelliJ than in Web and VS Code.

**Blank lines.** `isBlank()` and `trim() === ""` cover different whitespace, so an NBSP-only line
moved the continuation boundary on one side only. This one was found while verifying the first.

## Neither side was right

Measured against the reference renderer (`react-markdown` + `remark-gfm`, the same reference the
existing folding tests compare to):

| Source | Reference | Kotlin | TypeScript |
|---|---|---|---|
| `- [x] a\r` | 1 | 1 | **0** |
| `- [x] a\r\r\n- [x] b` | 2 | 2 | **1** |
| `- [x] a\n- [x] b\r` | 2 | 2 | **1** |
| `- [x] a\r- [x] b` | 2 | **0** | **0** |

| Blank-line candidate | Reference | Kotlin | TypeScript |
|---|---|---|---|
| U+00A0, U+FEFF, U+2007, U+202F | not blank | not blank | **blank** |
| U+001C | not blank | **blank** | not blank |

CommonMark counts a lone `\r` as a line ending and counts only spaces and tabs as blank. Aligning
Kotlin down to TypeScript's answer — the fix the issue suggests — would have settled both on the
wrong result and left the last row of the first table broken on both sides.

## What changed

- All three CommonMark line endings normalised to `\n` before the split, on both sides.
- An explicit `[ \t]` predicate does the blank test and the trims on both sides, replacing
  `trim() === ""` / `isBlank()` at four sites each.
- Kotlin's `CHECKBOX_RE` and `SECTION_RE` move to `\z`, matching what `BLOCK_OPENER_RE` already does.
  Not cosmetic: Java's `$` also admits U+2028 / U+2029, which `\z` closes.
- Mirrored tests on both sides for every case, written with escape sequences rather than literal
  characters.

**U+0085 stays divergent** and is pinned by a test on each side rather than fixed — it is an ordinary
character to JS's `.` and a terminator to Java's, and closing it needs an identical negated class in
both engines' `(.+)`, which is not worth the cost for a character with no natural source in a task
list.

## Verification

Each new test was checked against a temporarily reverted implementation, since a test that passes on
the old code proves nothing: 5 turn red on the TypeScript side, 4 on the Kotlin side. The two sets
differ because each guards the direction the *other* runtime got wrong; the rest are regression
guards and the documented exception.

Gates: `type-check`, `lint`, `npm test` (207 + 24 + 60), `./gradlew test` (40) — all green.

## Note for whoever cuts the release

`@spekjs/core` changes observable output for files with CR line endings or exotic whitespace (nothing
in this repo — verified by scanning every `.md` for those characters). That warrants a **minor** bump,
not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjHibWXs9MTLcVmewMXDrL