### PR TITLE
fix(build): make core/ui build scripts cross-platform (Windows)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "prepare": "tsc",
     "dev": "tsc --watch",
     "type-check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,8 +38,8 @@
     "./styles.css": "./dist/styles.css"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && npm run build:css",
-    "build:css": "cp src/styles.css dist/styles.css",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc && npm run build:css",
+    "build:css": "node -e \"require('fs').copyFileSync('src/styles.css','dist/styles.css')\"",
     "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "type-check": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",


### PR DESCRIPTION
`@spekjs/core` and `@spekjs/ui` build scripts shelled out to `rm -rf` and `cp`, which don't exist in `cmd.exe` — npm's default script shell on Windows. From a clean checkout, `npm run build`, `build:webview`, and `build:demo` all die on Windows (the failure lands at the end of ui's build, after `dist/*.js` is already emitted, so it reads as unrelated). CI is Linux, so it never surfaced upstream.

## Fix

Replace the two Unix-only commands with `node -e` stdlib one-liners — no new dependencies, matching the `node -e` style already used in the root `version` script:

- core `build`: `rm -rf dist` → `node -e "require('fs').rmSync('dist',{recursive:true,force:true})"`
- ui `build:css`: `cp src/styles.css dist/styles.css` → `node -e "require('fs').copyFileSync('src/styles.css','dist/styles.css')"`

`{force:true}` means no error when `dist` is absent (first build). `&&` chaining already works in `cmd.exe`, so only the two commands needed replacing. Considered `shx`/`rimraf`; rejected — a build dep whose only use in this repo is these two lines, with no second consumer (every other script already uses portable tooling: `tsc`, `vite`, `tsx`, `esbuild`, `git`, `npx`).

## Validation

- **Windows** (native, `cmd.exe`): full `npm run build` (core + ui + web) runs clean; `dist/styles.css` copied.
- **Linux** (Podman `node:22`, Debian 12, fresh `npm install` with no host `node_modules`): `build:core` + `build:ui` run clean; `packages/core/dist/index.js` present and `packages/ui/dist/styles.css` non-empty. This confirms the one-liners work where `rm -rf`/`cp` already did, so the change is portable rather than Windows-only.
